### PR TITLE
clarify lifetime on Operator::gradient().

### DIFF
--- a/src/operator.rs
+++ b/src/operator.rs
@@ -8,12 +8,15 @@ pub(crate) trait Operator<'hw> {
     fn name(&self) -> String;
     fn input_size(&self) -> usize;
     fn perform(&self, inputs: &[&Array<'hw>]) -> Result<Array<'hw>>;
-    fn gradient<'op, 'g>(
+    fn gradient<'op: 'g, 'g>(
         &self,
         _x: &[Node<'hw, 'op, 'g>],
         _y: Node<'hw, 'op, 'g>,
         _gy: Node<'hw, 'op, 'g>,
-    ) -> Result<Vec<Node<'hw, 'op, 'g>>> {
+    ) -> Result<Vec<Node<'hw, 'op, 'g>>>
+    where
+        'hw: 'op,
+    {
         Err(Error::NotSupported(format!(
             "No gradient definition for {}",
             self.name(),

--- a/src/operator/add.rs
+++ b/src/operator/add.rs
@@ -24,12 +24,15 @@ impl<'hw> Operator<'hw> for Add {
         inputs[0].elementwise_add_f32(inputs[1])
     }
 
-    fn gradient<'op, 'g>(
+    fn gradient<'op: 'g, 'g>(
         &self,
         _x: &[Node<'hw, 'op, 'g>],
         _y: Node<'hw, 'op, 'g>,
         gy: Node<'hw, 'op, 'g>,
-    ) -> Result<Vec<Node<'hw, 'op, 'g>>> {
+    ) -> Result<Vec<Node<'hw, 'op, 'g>>>
+    where
+        'hw: 'op,
+    {
         Ok(vec![gy, gy])
     }
 }

--- a/src/operator/div.rs
+++ b/src/operator/div.rs
@@ -24,12 +24,15 @@ impl<'hw> Operator<'hw> for Div {
         inputs[0].elementwise_div_f32(inputs[1])
     }
 
-    fn gradient<'op, 'g>(
+    fn gradient<'op: 'g, 'g>(
         &self,
         x: &[Node<'hw, 'op, 'g>],
         y: Node<'hw, 'op, 'g>,
         gy: Node<'hw, 'op, 'g>,
-    ) -> Result<Vec<Node<'hw, 'op, 'g>>> {
+    ) -> Result<Vec<Node<'hw, 'op, 'g>>>
+    where
+        'hw: 'op,
+    {
         let gx0 = gy / x[1];
         Ok(vec![gx0, -y * gx0])
     }

--- a/src/operator/mul.rs
+++ b/src/operator/mul.rs
@@ -24,12 +24,15 @@ impl<'hw> Operator<'hw> for Mul {
         inputs[0].elementwise_mul_f32(inputs[1])
     }
 
-    fn gradient<'op, 'g>(
+    fn gradient<'op: 'g, 'g>(
         &self,
         x: &[Node<'hw, 'op, 'g>],
         _y: Node<'hw, 'op, 'g>,
         gy: Node<'hw, 'op, 'g>,
-    ) -> Result<Vec<Node<'hw, 'op, 'g>>> {
+    ) -> Result<Vec<Node<'hw, 'op, 'g>>>
+    where
+        'hw: 'op,
+    {
         Ok(vec![gy * x[1], gy * x[0]])
     }
 }

--- a/src/operator/neg.rs
+++ b/src/operator/neg.rs
@@ -24,12 +24,15 @@ impl<'hw> Operator<'hw> for Neg {
         inputs[0].elementwise_neg_f32()
     }
 
-    fn gradient<'op, 'g>(
+    fn gradient<'op: 'g, 'g>(
         &self,
         _x: &[Node<'hw, 'op, 'g>],
         _y: Node<'hw, 'op, 'g>,
         gy: Node<'hw, 'op, 'g>,
-    ) -> Result<Vec<Node<'hw, 'op, 'g>>> {
+    ) -> Result<Vec<Node<'hw, 'op, 'g>>>
+    where
+        'hw: 'op,
+    {
         Ok(vec![-gy])
     }
 }

--- a/src/operator/sub.rs
+++ b/src/operator/sub.rs
@@ -24,12 +24,15 @@ impl<'hw> Operator<'hw> for Sub {
         inputs[0].elementwise_sub_f32(inputs[1])
     }
 
-    fn gradient<'op, 'g>(
+    fn gradient<'op: 'g, 'g>(
         &self,
         _x: &[Node<'hw, 'op, 'g>],
         _y: Node<'hw, 'op, 'g>,
         gy: Node<'hw, 'op, 'g>,
-    ) -> Result<Vec<Node<'hw, 'op, 'g>>> {
+    ) -> Result<Vec<Node<'hw, 'op, 'g>>>
+    where
+        'hw: 'op,
+    {
         Ok(vec![gy, -gy])
     }
 }


### PR DESCRIPTION
This PR adds some constraints of lifetimes of `Operator::gradient` to follow `Node`'s specification:
- `'op: 'g`
- `'hw: 'op`