### PR TITLE
Add Operator::forward_shape() and remove Copy from Shape

### DIFF
--- a/src/operator.rs
+++ b/src/operator.rs
@@ -2,11 +2,13 @@ use crate::array::Array;
 use crate::error::Error;
 use crate::node::Node;
 use crate::result::Result;
+use crate::shape::Shape;
 
 /// Operator represents an individual computation process in the computation graph.
 pub(crate) trait Operator<'hw> {
     fn name(&self) -> String;
     fn input_size(&self) -> usize;
+    fn perform_shape(&self, inputs: &[&Shape]) -> Result<Shape>;
     fn perform(&self, inputs: &[&Array<'hw>]) -> Result<Array<'hw>>;
     fn gradient<'op: 'g, 'g>(
         &self,

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -8,12 +8,15 @@ pub(crate) trait Operator<'hw> {
     fn name(&self) -> String;
     fn input_size(&self) -> usize;
     fn perform(&self, inputs: &[&Array<'hw>]) -> Result<Array<'hw>>;
-    fn gradient<'op, 'g>(
+    fn gradient<'op: 'g, 'g>(
         &self,
         _x: &[Node<'hw, 'op, 'g>],
         _y: Node<'hw, 'op, 'g>,
         _gy: Node<'hw, 'op, 'g>,
-    ) -> Result<Vec<Node<'hw, 'op, 'g>>> {
+    ) -> Result<Vec<Node<'hw, 'op, 'g>>>
+    where
+        'hw: 'op,
+    {
         Err(Error::NotSupported(format!(
             "No gradient definition for {}",
             self.name(),

--- a/src/operator/add.rs
+++ b/src/operator/add.rs
@@ -24,12 +24,15 @@ impl<'hw> Operator<'hw> for Add {
         inputs[0].elementwise_add_f32(inputs[1])
     }
 
-    fn gradient<'op, 'g>(
+    fn gradient<'op: 'g, 'g>(
         &self,
         _x: &[Node<'hw, 'op, 'g>],
         _y: Node<'hw, 'op, 'g>,
         gy: Node<'hw, 'op, 'g>,
-    ) -> Result<Vec<Node<'hw, 'op, 'g>>> {
+    ) -> Result<Vec<Node<'hw, 'op, 'g>>>
+    where
+        'hw: 'op,
+    {
         Ok(vec![gy, gy])
     }
 }

--- a/src/operator/add.rs
+++ b/src/operator/add.rs
@@ -2,6 +2,7 @@ use crate::array::Array;
 use crate::node::Node;
 use crate::operator::Operator;
 use crate::result::Result;
+use crate::shape::Shape;
 
 pub(crate) struct Add;
 
@@ -18,6 +19,10 @@ impl<'hw> Operator<'hw> for Add {
 
     fn input_size(&self) -> usize {
         2
+    }
+
+    fn perform_shape(&self, inputs: &[&Shape]) -> Result<Shape> {
+        inputs[0].elementwise(inputs[1])
     }
 
     fn perform(&self, inputs: &[&Array<'hw>]) -> Result<Array<'hw>> {

--- a/src/operator/constant.rs
+++ b/src/operator/constant.rs
@@ -1,6 +1,7 @@
 use crate::array::Array;
 use crate::operator::Operator;
 use crate::result::Result;
+use crate::shape::Shape;
 
 pub(crate) struct Constant<'hw> {
     value: Array<'hw>,
@@ -19,6 +20,10 @@ impl<'hw> Operator<'hw> for Constant<'hw> {
 
     fn input_size(&self) -> usize {
         0
+    }
+
+    fn perform_shape(&self, _inputs: &[&Shape]) -> Result<Shape> {
+        Ok(self.value.shape().clone())
     }
 
     fn perform(&self, _inputs: &[&Array<'hw>]) -> Result<Array<'hw>> {

--- a/src/operator/div.rs
+++ b/src/operator/div.rs
@@ -2,6 +2,7 @@ use crate::array::Array;
 use crate::node::Node;
 use crate::operator::Operator;
 use crate::result::Result;
+use crate::shape::Shape;
 
 pub(crate) struct Div;
 
@@ -18,6 +19,10 @@ impl<'hw> Operator<'hw> for Div {
 
     fn input_size(&self) -> usize {
         2
+    }
+
+    fn perform_shape(&self, inputs: &[&Shape]) -> Result<Shape> {
+        inputs[0].elementwise(inputs[1])
     }
 
     fn perform(&self, inputs: &[&Array<'hw>]) -> Result<Array<'hw>> {

--- a/src/operator/div.rs
+++ b/src/operator/div.rs
@@ -24,12 +24,15 @@ impl<'hw> Operator<'hw> for Div {
         inputs[0].elementwise_div_f32(inputs[1])
     }
 
-    fn gradient<'op, 'g>(
+    fn gradient<'op: 'g, 'g>(
         &self,
         x: &[Node<'hw, 'op, 'g>],
         y: Node<'hw, 'op, 'g>,
         gy: Node<'hw, 'op, 'g>,
-    ) -> Result<Vec<Node<'hw, 'op, 'g>>> {
+    ) -> Result<Vec<Node<'hw, 'op, 'g>>>
+    where
+        'hw: 'op,
+    {
         let gx0 = gy / x[1];
         Ok(vec![gx0, -y * gx0])
     }

--- a/src/operator/mul.rs
+++ b/src/operator/mul.rs
@@ -2,6 +2,7 @@ use crate::array::Array;
 use crate::node::Node;
 use crate::operator::Operator;
 use crate::result::Result;
+use crate::shape::Shape;
 
 pub(crate) struct Mul;
 
@@ -18,6 +19,10 @@ impl<'hw> Operator<'hw> for Mul {
 
     fn input_size(&self) -> usize {
         2
+    }
+
+    fn perform_shape(&self, inputs: &[&Shape]) -> Result<Shape> {
+        inputs[0].elementwise(inputs[1])
     }
 
     fn perform(&self, inputs: &[&Array<'hw>]) -> Result<Array<'hw>> {

--- a/src/operator/mul.rs
+++ b/src/operator/mul.rs
@@ -24,12 +24,15 @@ impl<'hw> Operator<'hw> for Mul {
         inputs[0].elementwise_mul_f32(inputs[1])
     }
 
-    fn gradient<'op, 'g>(
+    fn gradient<'op: 'g, 'g>(
         &self,
         x: &[Node<'hw, 'op, 'g>],
         _y: Node<'hw, 'op, 'g>,
         gy: Node<'hw, 'op, 'g>,
-    ) -> Result<Vec<Node<'hw, 'op, 'g>>> {
+    ) -> Result<Vec<Node<'hw, 'op, 'g>>>
+    where
+        'hw: 'op,
+    {
         Ok(vec![gy * x[1], gy * x[0]])
     }
 }

--- a/src/operator/neg.rs
+++ b/src/operator/neg.rs
@@ -2,6 +2,7 @@ use crate::array::Array;
 use crate::node::Node;
 use crate::operator::Operator;
 use crate::result::Result;
+use crate::shape::Shape;
 
 pub(crate) struct Neg;
 
@@ -18,6 +19,10 @@ impl<'hw> Operator<'hw> for Neg {
 
     fn input_size(&self) -> usize {
         1
+    }
+
+    fn perform_shape(&self, inputs: &[&Shape]) -> Result<Shape> {
+        Ok(inputs[0].clone())
     }
 
     fn perform(&self, inputs: &[&Array<'hw>]) -> Result<Array<'hw>> {

--- a/src/operator/neg.rs
+++ b/src/operator/neg.rs
@@ -24,12 +24,15 @@ impl<'hw> Operator<'hw> for Neg {
         inputs[0].elementwise_neg_f32()
     }
 
-    fn gradient<'op, 'g>(
+    fn gradient<'op: 'g, 'g>(
         &self,
         _x: &[Node<'hw, 'op, 'g>],
         _y: Node<'hw, 'op, 'g>,
         gy: Node<'hw, 'op, 'g>,
-    ) -> Result<Vec<Node<'hw, 'op, 'g>>> {
+    ) -> Result<Vec<Node<'hw, 'op, 'g>>>
+    where
+        'hw: 'op,
+    {
         Ok(vec![-gy])
     }
 }

--- a/src/operator/sub.rs
+++ b/src/operator/sub.rs
@@ -24,12 +24,15 @@ impl<'hw> Operator<'hw> for Sub {
         inputs[0].elementwise_sub_f32(inputs[1])
     }
 
-    fn gradient<'op, 'g>(
+    fn gradient<'op: 'g, 'g>(
         &self,
         _x: &[Node<'hw, 'op, 'g>],
         _y: Node<'hw, 'op, 'g>,
         gy: Node<'hw, 'op, 'g>,
-    ) -> Result<Vec<Node<'hw, 'op, 'g>>> {
+    ) -> Result<Vec<Node<'hw, 'op, 'g>>>
+    where
+        'hw: 'op,
+    {
         Ok(vec![gy, -gy])
     }
 }

--- a/src/operator/sub.rs
+++ b/src/operator/sub.rs
@@ -2,6 +2,7 @@ use crate::array::Array;
 use crate::node::Node;
 use crate::operator::Operator;
 use crate::result::Result;
+use crate::shape::Shape;
 
 pub(crate) struct Sub;
 
@@ -18,6 +19,10 @@ impl<'hw> Operator<'hw> for Sub {
 
     fn input_size(&self) -> usize {
         2
+    }
+
+    fn perform_shape(&self, inputs: &[&Shape]) -> Result<Shape> {
+        inputs[0].elementwise(inputs[1])
     }
 
     fn perform(&self, inputs: &[&Array<'hw>]) -> Result<Array<'hw>> {

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -7,7 +7,7 @@ use std::mem::size_of;
 const MAX_NUM_DIMENSIONS: usize = 8;
 
 /// Shape of a value.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Shape {
     /// Number of dimensions of the shape.
     /// Only values in `dimensions` with indices smaller than `num_dimensions` are available.
@@ -187,7 +187,7 @@ impl Shape {
     /// * `Err(Error)` - Operation failed.
     pub fn elementwise(&self, other: &Self) -> Result<Self> {
         if self == other {
-            Ok(*self)
+            Ok(self.clone())
         } else {
             Err(Error::InvalidShape(format!(
                 "Elementwise operation can not be evaluated for hapes {} and {}.",


### PR DESCRIPTION
This PR contains:
- Add `Operator::forward_shape()` which is required to propagate shape information before actual computation.
- Remove `Copy` trait from `Shape` because the object is somewhat heavy.