### PR TITLE
Fix typo

### DIFF
--- a/src/shape.rs
+++ b/src/shape.rs
@@ -190,7 +190,7 @@ impl Shape {
             Ok(*self)
         } else {
             Err(Error::InvalidShape(format!(
-                "Elementwise operation can not be evaluated for hapes {} and {}.",
+                "Elementwise operation can not be evaluated for shapes {} and {}.",
                 self, other
             )))
         }


### PR DESCRIPTION
This fixes a typo in the error message in `Shape`'s `elementwise` method.