### PR TITLE
Replace Option<Array> in Graph to ArrayPlaceholder.

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -7,11 +7,19 @@ use crate::shape::Shape;
 /// Placeholder of `Array`s.
 /// Unlike `Option`, the object always holds its `Shape` informatin.
 pub(crate) enum ArrayPlaceholder<'hw> {
+    /// `Array` is not assigned, while its `Shape` is known.
     Unassigned(Shape),
+
+    /// `Array` is assigned.
     Assigned(Array<'hw>),
 }
 
 impl<'hw> ArrayPlaceholder<'hw> {
+    /// Obtains the `Shape` of this placeholder.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the inner `Shape` object.
     pub(crate) fn shape(&self) -> &Shape {
         match self {
             Self::Unassigned(ref shape) => shape,
@@ -19,6 +27,12 @@ impl<'hw> ArrayPlaceholder<'hw> {
         }
     }
 
+    /// Obtains the `Array` if the placeholder holds it.
+    ///
+    /// # Returns
+    ///
+    /// * `Some(&Array)` - A reference to the inner `Array` object.
+    /// * `None` - The placeholder does not hold the `Array` object.
     pub(crate) fn array(&self) -> Option<&Array<'hw>> {
         match self {
             Self::Unassigned(_) => None,

--- a/src/node.rs
+++ b/src/node.rs
@@ -4,6 +4,7 @@ use crate::graph::Graph;
 use crate::hardware::Hardware;
 use crate::operator;
 use crate::result::Result;
+use crate::shape::Shape;
 use std::cell::RefCell;
 use std::fmt;
 use std::ptr;
@@ -61,6 +62,16 @@ impl<'hw: 'op, 'op: 'g, 'g> Node<'hw, 'op, 'g> {
                     "Attempted calculation between Nodes on different Graph.".to_string(),
                 )
             })
+    }
+
+    pub fn shape(&self) -> Shape {
+        self.graph
+            .borrow()
+            .get_step(self.step_id)
+            .unwrap()
+            .output
+            .shape()
+            .clone()
     }
 
     pub fn calculate(&self) -> Result<Array<'hw>> {
@@ -219,6 +230,10 @@ mod tests {
         let rhs = Node::from_scalar(&hw, &g, 2.);
         let ret = lhs + rhs;
 
+        assert_eq!(lhs.shape(), make_shape![]);
+        assert_eq!(rhs.shape(), make_shape![]);
+        assert_eq!(ret.shape(), make_shape![]);
+
         {
             let g = g.borrow();
             assert_eq!(g.num_steps(), 3);
@@ -243,6 +258,10 @@ mod tests {
 
         let src = Node::from_scalar(&hw, &g, 42.);
         let dest = -src;
+
+        assert_eq!(src.shape(), make_shape![]);
+        assert_eq!(dest.shape(), make_shape![]);
+
         assert_eq!(dest.calculate().unwrap().to_scalar(), Ok(-42.));
     }
 
@@ -254,6 +273,11 @@ mod tests {
         let lhs = Node::from_scalar(&hw, &g, 1.);
         let rhs = Node::from_scalar(&hw, &g, 2.);
         let ret = lhs + rhs;
+
+        assert_eq!(lhs.shape(), make_shape![]);
+        assert_eq!(rhs.shape(), make_shape![]);
+        assert_eq!(ret.shape(), make_shape![]);
+
         assert_eq!(ret.calculate().unwrap().to_scalar(), Ok(3.));
     }
 
@@ -265,6 +289,11 @@ mod tests {
         let lhs = Node::from_scalar(&hw, &g, 1.);
         let rhs = Node::from_scalar(&hw, &g, 2.);
         let ret = lhs - rhs;
+
+        assert_eq!(lhs.shape(), make_shape![]);
+        assert_eq!(rhs.shape(), make_shape![]);
+        assert_eq!(ret.shape(), make_shape![]);
+
         assert_eq!(ret.calculate().unwrap().to_scalar(), Ok(-1.));
     }
 
@@ -276,6 +305,11 @@ mod tests {
         let lhs = Node::from_scalar(&hw, &g, 1.);
         let rhs = Node::from_scalar(&hw, &g, 2.);
         let ret = lhs * rhs;
+
+        assert_eq!(lhs.shape(), make_shape![]);
+        assert_eq!(rhs.shape(), make_shape![]);
+        assert_eq!(ret.shape(), make_shape![]);
+
         assert_eq!(ret.calculate().unwrap().to_scalar(), Ok(2.));
     }
 
@@ -287,6 +321,11 @@ mod tests {
         let lhs = Node::from_scalar(&hw, &g, 1.);
         let rhs = Node::from_scalar(&hw, &g, 2.);
         let ret = lhs / rhs;
+
+        assert_eq!(lhs.shape(), make_shape![]);
+        assert_eq!(rhs.shape(), make_shape![]);
+        assert_eq!(ret.shape(), make_shape![]);
+
         assert_eq!(ret.calculate().unwrap().to_scalar(), Ok(0.5));
     }
 
@@ -299,6 +338,12 @@ mod tests {
         let b = Node::from_scalar(&hw, &g, 2.);
         let c = Node::from_scalar(&hw, &g, 3.);
         let y = a + -b * c;
+
+        assert_eq!(a.shape(), make_shape![]);
+        assert_eq!(b.shape(), make_shape![]);
+        assert_eq!(c.shape(), make_shape![]);
+        assert_eq!(y.shape(), make_shape![]);
+
         assert_eq!(y.calculate().unwrap().to_scalar(), Ok(-5.));
     }
 }


### PR DESCRIPTION
This PR introduces `ArrayPlaceholder`, a value placeholder of inner data of `Graph` which always holds its `Shape` information. `Shape` needs to be calculated immediately when a new step is added since some functions (like `grad`) requires them.