### PR TITLE
Array refine

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -487,13 +487,6 @@ mod tests {
     }
 
     #[test]
-    fn test_set_scalar_f32_n() {
-        let hw = RefCell::new(CpuHardware::new());
-        let mut array = unsafe { Array::raw(&hw, make_shape![42]) };
-        assert!(array.set_scalar_f32(123.).is_err());
-    }
-
-    #[test]
     fn test_set_scalar_f32_1() {
         let hw = RefCell::new(CpuHardware::new());
         let mut array = unsafe { Array::raw(&hw, make_shape![1]) };
@@ -501,16 +494,23 @@ mod tests {
     }
 
     #[test]
-    fn test_get_scalar_f32_n() {
+    fn test_set_scalar_f32_n() {
         let hw = RefCell::new(CpuHardware::new());
-        let array = unsafe { Array::raw(&hw, make_shape![42]) };
-        assert!(array.get_scalar_f32().is_err());
+        let mut array = unsafe { Array::raw(&hw, make_shape![42]) };
+        assert!(array.set_scalar_f32(123.).is_err());
     }
 
     #[test]
     fn test_get_scalar_f32_1() {
         let hw = RefCell::new(CpuHardware::new());
         let array = unsafe { Array::raw(&hw, make_shape![1]) };
+        assert!(array.get_scalar_f32().is_err());
+    }
+
+    #[test]
+    fn test_get_scalar_f32_n() {
+        let hw = RefCell::new(CpuHardware::new());
+        let array = unsafe { Array::raw(&hw, make_shape![42]) };
         assert!(array.get_scalar_f32().is_err());
     }
 

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,10 +1,11 @@
 use crate::buffer::Buffer;
+use crate::error::Error;
 use crate::hardware::Hardware;
 use crate::make_shape;
 use crate::result::Result;
 use crate::shape::Shape;
 use std::cell::RefCell;
-use std::mem::size_of;
+use std::mem;
 
 /// A multidimensional array with specific computing backend.
 ///
@@ -34,7 +35,7 @@ impl<'hw> Array<'hw> {
     ///
     /// This function does not initialize the inner memory.
     /// Users are responsible to initialize the memory immediately by themselves.
-    pub(crate) unsafe fn raw(hardware: &'hw RefCell<dyn Hardware>, shape: Shape) -> Self {
+    pub unsafe fn raw(hardware: &'hw RefCell<dyn Hardware>, shape: Shape) -> Self {
         let size = shape.memory_size::<f32>();
         Self {
             shape,
@@ -57,7 +58,7 @@ impl<'hw> Array<'hw> {
     ///
     /// This function does not initialize the inner memory.
     /// Users are responsible to initialize the memory immediately by themselves.
-    pub(crate) unsafe fn raw_colocated(other: &Self, shape: Shape) -> Self {
+    pub unsafe fn raw_colocated(other: &Self, shape: Shape) -> Self {
         let size = shape.memory_size::<f32>();
         Self {
             shape,
@@ -72,7 +73,7 @@ impl<'hw> Array<'hw> {
     /// Reference to the `Shape` object.
     ///
     /// Shape of the array.
-    pub(crate) fn shape(&self) -> &Shape {
+    pub fn shape(&self) -> &Shape {
         &self.shape
     }
 
@@ -86,34 +87,16 @@ impl<'hw> Array<'hw> {
     ///
     /// * `Ok(())` - New value is set correctly.
     /// * `Err(Error)` - Array is not a scalar.
-    pub(crate) fn set_scalar(&mut self, value: f32) -> Result<()> {
+    pub fn set_scalar_f32(&mut self, value: f32) -> Result<()> {
         self.shape.check_is_scalar()?;
         unsafe {
             self.buffer.hardware().borrow_mut().copy_host_to_hardware(
                 (&value as *const f32) as *const u8,
                 self.buffer.as_mut_handle(),
-                size_of::<f32>(),
+                mem::size_of::<f32>(),
             )
         }
         Ok(())
-    }
-
-    /// Creates a new `Array` on the specific hardware.
-    ///
-    /// # Arguments
-    ///
-    /// * `hardware`: `Hardware` object to host the value.
-    /// * `value`: Value of the resulting array.
-    ///
-    /// # Returns
-    ///
-    /// A new `Array` object representing a scalar value.
-    pub(crate) fn new_scalar(hardware: &'hw RefCell<dyn Hardware>, value: f32) -> Self {
-        unsafe {
-            let mut array = Self::raw(hardware, make_shape![]);
-            array.set_scalar(value).unwrap();
-            array
-        }
     }
 
     /// Obtains scalar value of this array.
@@ -126,17 +109,147 @@ impl<'hw> Array<'hw> {
     ///
     /// * `Ok(f32)` - Scalar value obtained from the array.
     /// * `Err(Error)` - Array is not a scalar.
-    pub(crate) fn to_scalar(&self) -> Result<f32> {
+    pub fn get_scalar_f32(&self) -> Result<f32> {
         self.shape.check_is_scalar()?;
         let mut value = 0.;
         unsafe {
             self.buffer.hardware().borrow_mut().copy_hardware_to_host(
                 self.buffer.as_handle(),
                 (&mut value as *mut f32) as *mut u8,
-                size_of::<f32>(),
+                mem::size_of::<f32>(),
             );
         }
         Ok(value)
+    }
+
+    /// Sets all values in the underlying buffer.
+    ///
+    /// # Arguments
+    ///
+    /// * `values` - Sequence of values to be set. The length must be the same as the size of
+    ///   the underlying buffer.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - Values are set correctly.
+    /// * `Err(Error)` - Length of the specified values is different with the size of the
+    ///   underlying buffer.
+    pub fn set_values_f32(&mut self, values: &[f32]) -> Result<()> {
+        if values.len() != self.shape.num_elements() {
+            return Err(Error::InvalidLength(format!(
+                "Values has a different length. Required {}, but got {}.",
+                self.shape.num_elements(),
+                values.len(),
+            )));
+        }
+
+        unsafe {
+            self.buffer.hardware().borrow_mut().copy_host_to_hardware(
+                values.as_ptr() as *const u8,
+                self.buffer.as_mut_handle(),
+                self.shape.num_elements() * mem::size_of::<f32>(),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Obtains all values in the underlying buffer.
+    ///
+    /// # Returns
+    ///
+    /// `Vec` of all values. The order of values is row-major order (C order).
+    pub fn get_values_f32(&self) -> Vec<f32> {
+        let num_elements = self.shape.num_elements();
+        let mut values = Vec::<f32>::with_capacity(num_elements);
+        unsafe {
+            self.buffer.hardware().borrow_mut().copy_hardware_to_host(
+                self.buffer.as_handle(),
+                values.as_mut_ptr() as *mut u8,
+                num_elements * mem::size_of::<f32>(),
+            );
+            values.set_len(num_elements);
+        }
+        values
+    }
+
+    /// Creates a new `Array` with 0-dimensional shape on the specific hardware.
+    ///
+    /// # Arguments
+    ///
+    /// * `hardware`: `Hardware` object to host the value.
+    /// * `value`: Value of the resulting array.
+    ///
+    /// # Returns
+    ///
+    /// A new `Array` object representing a scalar value.
+    pub fn scalar_f32(hardware: &'hw RefCell<dyn Hardware>, value: f32) -> Self {
+        let mut array = unsafe { Self::raw(hardware, make_shape![]) };
+        array.set_scalar_f32(value).unwrap();
+        array
+    }
+
+    /// Creates a new `Array` with arbitrary shape on the specific hardware.
+    ///
+    /// # Arguments
+    ///
+    /// * `hardware`: `Hardware` object to host the value.
+    /// * `shape`: `Shape` of the new `Array`.
+    /// * `value`: Values copied to the underlying buffer. The number of values must be the same as
+    ///   the size of the underlying buffer.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Array)` - A new `Array` object.
+    /// * Err(Error)` - Some error occurred during the process.
+    pub fn constant_f32(
+        hardware: &'hw RefCell<dyn Hardware>,
+        shape: Shape,
+        values: &[f32],
+    ) -> Result<Self> {
+        let mut array = unsafe { Self::raw(hardware, shape) };
+        array.set_values_f32(values)?;
+        Ok(array)
+    }
+
+    /// Creates a new `Array` with a specified `Shape` filled by a single value.
+    ///
+    /// # Arguments
+    ///
+    /// * `hardware`: `Hardware` object to host the value.
+    /// * `shape` - `Spahe` of the resulting `Array`.
+    /// * `value` - Value of the elements.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Array)` - A new `Array` object.
+    /// * `Err(Error)` - Some error occurred during the process.
+    pub fn fill_f32(hardware: &'hw RefCell<dyn Hardware>, shape: Shape, value: f32) -> Self {
+        unsafe {
+            let mut array = Self::raw(hardware, shape);
+            hardware.borrow_mut().fill_f32(
+                array.buffer.as_mut_handle(),
+                value,
+                array.shape.num_elements(),
+            );
+            array
+        }
+    }
+
+    /// Creates a new `Array` with a specified `Shape` filled by a single value, colocated with an existing `Array`.
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - An `Array` object on the desired hardware.
+    /// * `shape` - `Shape` of the resulting `Array`.
+    /// * `value` - Value of the elements.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Array)` - A new `Array` object.
+    /// * `Err(Error)` - Some error occurred during the process.
+    pub fn fill_colocated_f32(other: &Self, shape: Shape, value: f32) -> Self {
+        Self::fill_f32(other.buffer.hardware(), shape, value)
     }
 
     /// Performs elementwise negation operation and returns a new `Array` of resulting
@@ -148,7 +261,7 @@ impl<'hw> Array<'hw> {
     ///
     /// * `Ok(Array)` - A new `Array` holding the results.
     /// * `Err(Error)` - The operation can not be evaluated for given arguments.
-    pub(crate) fn elementwise_neg_f32(&self) -> Result<Self> {
+    pub fn elementwise_neg_f32(&self) -> Self {
         unsafe {
             let mut output = Self::raw_colocated(self, self.shape.clone());
             output.buffer.hardware().borrow_mut().elementwise_neg_f32(
@@ -156,7 +269,7 @@ impl<'hw> Array<'hw> {
                 output.buffer.as_mut_handle(),
                 self.shape.num_elements(),
             );
-            Ok(output)
+            output
         }
     }
 
@@ -172,7 +285,7 @@ impl<'hw> Array<'hw> {
     ///
     /// * `Ok(Array)` - A new `Array` holding the results.
     /// * `Err(Error)` - The operation can not be evaluated for given arguments.
-    pub(crate) fn elementwise_add_f32(&self, other: &Self) -> Result<Self> {
+    pub fn elementwise_add_f32(&self, other: &Self) -> Result<Self> {
         self.buffer.check_colocated(&other.buffer)?;
         let output_shape = self.shape.elementwise(&other.shape)?;
         let num_elements = output_shape.num_elements();
@@ -200,7 +313,7 @@ impl<'hw> Array<'hw> {
     ///
     /// * `Ok(Array)` - A new `Array` holding the results.
     /// * `Err(Error)` - The operation can not be evaluated for given arguments.
-    pub(crate) fn elementwise_sub_f32(&self, other: &Self) -> Result<Self> {
+    pub fn elementwise_sub_f32(&self, other: &Self) -> Result<Self> {
         self.buffer.check_colocated(&other.buffer)?;
         let output_shape = self.shape.elementwise(&other.shape)?;
         let num_elements = output_shape.num_elements();
@@ -228,7 +341,7 @@ impl<'hw> Array<'hw> {
     ///
     /// * `Ok(Array)` - A new `Array` holding the results.
     /// * `Err(Error)` - The operation can not be evaluated for given arguments.
-    pub(crate) fn elementwise_mul_f32(&self, other: &Self) -> Result<Self> {
+    pub fn elementwise_mul_f32(&self, other: &Self) -> Result<Self> {
         self.buffer.check_colocated(&other.buffer)?;
         let output_shape = self.shape.elementwise(&other.shape)?;
         let num_elements = output_shape.num_elements();
@@ -256,7 +369,7 @@ impl<'hw> Array<'hw> {
     ///
     /// * `Ok(Array)` - A new `Array` holding the results.
     /// * `Err(Error)` - The operation can not be evaluated for given arguments.
-    pub(crate) fn elementwise_div_f32(&self, other: &Self) -> Result<Self> {
+    pub fn elementwise_div_f32(&self, other: &Self) -> Result<Self> {
         self.buffer.check_colocated(&other.buffer)?;
         let output_shape = self.shape.elementwise(&other.shape)?;
         let num_elements = output_shape.num_elements();
@@ -292,4 +405,256 @@ impl<'hw> Clone for Array<'hw> {
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use crate::array::Array;
+    use crate::hardware::cpu::CpuHardware;
+    use crate::make_shape;
+    use std::cell::RefCell;
+    use std::mem::size_of;
+    use std::ptr;
+
+    #[test]
+    fn test_raw_dim0() {
+        let hw = RefCell::new(CpuHardware::new());
+        let array = unsafe { Array::raw(&hw, make_shape![]) };
+        assert!(ptr::eq(array.buffer.hardware(), &hw));
+        assert_eq!(array.buffer.size(), size_of::<f32>());
+        assert_eq!(array.shape, make_shape![]);
+    }
+
+    #[test]
+    fn test_raw_dim1() {
+        let hw = RefCell::new(CpuHardware::new());
+        let array = unsafe { Array::raw(&hw, make_shape![42]) };
+        assert!(ptr::eq(array.buffer.hardware(), &hw));
+        assert_eq!(array.buffer.size(), 42 * size_of::<f32>());
+        assert_eq!(array.shape, make_shape![42]);
+    }
+
+    #[test]
+    fn test_raw_colocated_dim0() {
+        let hw = RefCell::new(CpuHardware::new());
+        let other = unsafe { Array::raw(&hw, make_shape![]) };
+        let colocated = unsafe { Array::raw_colocated(&other, make_shape![]) };
+        assert!(ptr::eq(colocated.buffer.hardware(), &hw));
+        assert_eq!(colocated.buffer.size(), size_of::<f32>());
+        assert_eq!(colocated.shape, make_shape![]);
+    }
+
+    #[test]
+    fn test_raw_colocated_dim1() {
+        let hw = RefCell::new(CpuHardware::new());
+        let other = unsafe { Array::raw(&hw, make_shape![]) };
+        let colocated = unsafe { Array::raw_colocated(&other, make_shape![42]) };
+        assert!(ptr::eq(colocated.buffer.hardware(), &hw));
+        assert_eq!(colocated.buffer.size(), 42 * size_of::<f32>());
+        assert_eq!(colocated.shape, make_shape![42]);
+    }
+
+    #[test]
+    fn test_shape() {
+        let hw = RefCell::new(CpuHardware::new());
+        let array = unsafe { Array::raw(&hw, make_shape![]) };
+        assert!(ptr::eq(array.shape(), &array.shape));
+    }
+
+    #[test]
+    fn test_set_scalar_f32_dim0() {
+        let hw = RefCell::new(CpuHardware::new());
+        let mut array = unsafe { Array::raw(&hw, make_shape![]) };
+        array.set_scalar_f32(123.).unwrap();
+        assert_eq!(array.get_scalar_f32(), Ok(123.));
+        assert_eq!(array.get_values_f32(), vec![123.]);
+    }
+
+    #[test]
+    fn test_set_scalar_f32_dim1() {
+        let hw = RefCell::new(CpuHardware::new());
+        let mut array = unsafe { Array::raw(&hw, make_shape![42]) };
+        assert!(array.set_scalar_f32(123.).is_err());
+    }
+
+    #[test]
+    fn test_set_scalar_f32_dim1_len1() {
+        let hw = RefCell::new(CpuHardware::new());
+        let mut array = unsafe { Array::raw(&hw, make_shape![1]) };
+        assert!(array.set_scalar_f32(123.).is_err());
+    }
+
+    #[test]
+    fn test_get_scalar_f32_dim1() {
+        let hw = RefCell::new(CpuHardware::new());
+        let array = unsafe { Array::raw(&hw, make_shape![42]) };
+        assert!(array.get_scalar_f32().is_err());
+    }
+
+    #[test]
+    fn test_get_scalar_f32_dim1_len1() {
+        let hw = RefCell::new(CpuHardware::new());
+        let array = unsafe { Array::raw(&hw, make_shape![1]) };
+        assert!(array.get_scalar_f32().is_err());
+    }
+
+    #[test]
+    fn test_set_values_f32_dim0() {
+        let hw = RefCell::new(CpuHardware::new());
+        let mut array = unsafe { Array::raw(&hw, make_shape![]) };
+        array.set_values_f32(&[123.]).unwrap();
+        assert_eq!(array.get_scalar_f32(), Ok(123.));
+        assert_eq!(array.get_values_f32(), vec![123.]);
+
+        assert!(array.set_values_f32(&[]).is_err());
+        assert!(array.set_values_f32(&[123., 456.]).is_err());
+        assert!(array.set_values_f32(&[123., 456., 789.]).is_err());
+    }
+
+    #[test]
+    fn test_set_values_f32_dim1() {
+        let hw = RefCell::new(CpuHardware::new());
+        let mut array = unsafe { Array::raw(&hw, make_shape![3]) };
+        array.set_values_f32(&[123., 456., 789.]).unwrap();
+        assert_eq!(array.get_values_f32(), vec![123., 456., 789.]);
+
+        assert!(array.set_values_f32(&[]).is_err());
+        assert!(array.set_values_f32(&[111.]).is_err());
+        assert!(array.set_values_f32(&[111., 222.]).is_err());
+        assert!(array.set_values_f32(&[111., 222., 333., 444.]).is_err());
+    }
+
+    #[test]
+    fn test_set_values_f32_dim1_len0() {
+        let hw = RefCell::new(CpuHardware::new());
+        let mut array = unsafe { Array::raw(&hw, make_shape![0]) };
+        array.set_values_f32(&[]).unwrap();
+        assert_eq!(array.get_values_f32(), vec![]);
+
+        assert!(array.set_values_f32(&[111.]).is_err());
+        assert!(array.set_values_f32(&[111., 222.]).is_err());
+    }
+
+    #[test]
+    fn test_scalar_f32() {
+        let hw = RefCell::new(CpuHardware::new());
+        let array = Array::scalar_f32(&hw, 123.);
+        assert_eq!(array.shape, make_shape![]);
+        assert_eq!(array.get_scalar_f32(), Ok(123.));
+        assert_eq!(array.get_values_f32(), vec![123.]);
+    }
+
+    #[test]
+    fn test_constant_f32_dim0() {
+        let hw = RefCell::new(CpuHardware::new());
+        let array = Array::constant_f32(&hw, make_shape![], &[123.]).unwrap();
+        assert_eq!(array.shape, make_shape![]);
+        assert_eq!(array.get_scalar_f32(), Ok(123.));
+        assert_eq!(array.get_values_f32(), vec![123.]);
+    }
+
+    #[test]
+    fn test_constant_f32_dim0_invalid() {
+        let hw = RefCell::new(CpuHardware::new());
+        assert!(Array::constant_f32(&hw, make_shape![], &[]).is_err());
+        assert!(Array::constant_f32(&hw, make_shape![], &[111., 222.]).is_err());
+    }
+
+    #[test]
+    fn test_constant_f32_dim1() {
+        let hw = RefCell::new(CpuHardware::new());
+        let array = Array::constant_f32(&hw, make_shape![3], &[123., 456., 789.]).unwrap();
+        assert_eq!(array.shape, make_shape![3]);
+        assert!(array.get_scalar_f32().is_err());
+        assert_eq!(array.get_values_f32(), vec![123., 456., 789.]);
+    }
+
+    #[test]
+    fn test_constant_f32_dim1_invalid() {
+        let hw = RefCell::new(CpuHardware::new());
+        assert!(Array::constant_f32(&hw, make_shape![3], &[]).is_err());
+        assert!(Array::constant_f32(&hw, make_shape![3], &[111.]).is_err());
+        assert!(Array::constant_f32(&hw, make_shape![3], &[111., 222.]).is_err());
+        assert!(Array::constant_f32(&hw, make_shape![3], &[111., 222., 333., 444.]).is_err());
+    }
+
+    #[test]
+    fn test_constant_f32_dim1_len0() {
+        let hw = RefCell::new(CpuHardware::new());
+        let array = Array::constant_f32(&hw, make_shape![0], &[]).unwrap();
+        assert_eq!(array.shape, make_shape![0]);
+        assert!(array.get_scalar_f32().is_err());
+        assert_eq!(array.get_values_f32(), vec![]);
+    }
+
+    #[test]
+    fn test_constant_f32_dim1_len0_invalid() {
+        let hw = RefCell::new(CpuHardware::new());
+        assert!(Array::constant_f32(&hw, make_shape![0], &[111.]).is_err());
+        assert!(Array::constant_f32(&hw, make_shape![0], &[111., 222.]).is_err());
+    }
+
+    #[test]
+    fn test_fill_f32_dim0() {
+        let hw = RefCell::new(CpuHardware::new());
+        let array = Array::fill_f32(&hw, make_shape![], 123.);
+        assert_eq!(array.shape, make_shape![]);
+        assert_eq!(array.get_scalar_f32(), Ok(123.));
+        assert_eq!(array.get_values_f32(), vec![123.]);
+    }
+
+    #[test]
+    fn test_fill_f32_dim1() {
+        let hw = RefCell::new(CpuHardware::new());
+        let array = Array::fill_f32(&hw, make_shape![3], 123.);
+        assert_eq!(array.shape, make_shape![3]);
+        assert!(array.get_scalar_f32().is_err());
+        assert_eq!(array.get_values_f32(), vec![123., 123., 123.]);
+    }
+
+    #[test]
+    fn test_fill_f32_dim1_len0() {
+        let hw = RefCell::new(CpuHardware::new());
+        let array = Array::fill_f32(&hw, make_shape![0], 123.);
+        assert_eq!(array.shape, make_shape![0]);
+        assert!(array.get_scalar_f32().is_err());
+        assert_eq!(array.get_values_f32(), vec![]);
+    }
+
+    #[test]
+    fn test_fill_colocated_f32_dim0() {
+        let hw = RefCell::new(CpuHardware::new());
+        let other = unsafe { Array::raw(&hw, make_shape![]) };
+        let array = Array::fill_colocated_f32(&other, make_shape![], 123.);
+        assert_eq!(array.shape, make_shape![]);
+        assert!(ptr::eq(array.buffer.hardware(), &hw));
+        assert_eq!(array.get_scalar_f32(), Ok(123.));
+        assert_eq!(array.get_values_f32(), vec![123.]);
+    }
+
+    #[test]
+    fn test_fill_colocated_f32_dim1() {
+        let hw = RefCell::new(CpuHardware::new());
+        let other = unsafe { Array::raw(&hw, make_shape![]) };
+        let array = Array::fill_colocated_f32(&other, make_shape![3], 123.);
+        assert_eq!(array.shape, make_shape![3]);
+        assert!(ptr::eq(array.buffer.hardware(), &hw));
+        assert!(array.get_scalar_f32().is_err());
+        assert_eq!(array.get_values_f32(), vec![123., 123., 123.]);
+    }
+
+    #[test]
+    fn test_fill_colocated_f32_dim1_len0() {
+        let hw = RefCell::new(CpuHardware::new());
+        let other = unsafe { Array::raw(&hw, make_shape![]) };
+        let array = Array::fill_colocated_f32(&other, make_shape![0], 123.);
+        assert_eq!(array.shape, make_shape![0]);
+        assert!(ptr::eq(array.buffer.hardware(), &hw));
+        assert!(array.get_scalar_f32().is_err());
+        assert_eq!(array.get_values_f32(), vec![]);
+    }
+
+    // neg
+    // add
+    // sub
+    // mul
+    // div
+    // clone
+}

--- a/src/array.rs
+++ b/src/array.rs
@@ -217,7 +217,7 @@ impl<'hw> Array<'hw> {
     /// # Arguments
     ///
     /// * `hardware`: `Hardware` object to host the value.
-    /// * `shape` - `Spahe` of the resulting `Array`.
+    /// * `shape` - `Shape` of the resulting `Array`.
     /// * `value` - Value of the elements.
     ///
     /// # Returns

--- a/src/array.rs
+++ b/src/array.rs
@@ -195,7 +195,7 @@ impl<'hw> Array<'hw> {
     ///
     /// * `hardware`: `Hardware` object to host the value.
     /// * `shape`: `Shape` of the new `Array`.
-    /// * `value`: Values copied to the underlying buffer. The number of values must be the same as
+    /// * `values`: Values to be copied to the underlying buffer. The number of values must be the same as
     ///   the size of the underlying buffer.
     ///
     /// # Returns

--- a/src/array.rs
+++ b/src/array.rs
@@ -528,6 +528,17 @@ mod tests {
     }
 
     #[test]
+    fn test_set_values_f32_0() {
+        let hw = RefCell::new(CpuHardware::new());
+        let mut array = unsafe { Array::raw(&hw, make_shape![0]) };
+        array.set_values_f32(&[]).unwrap();
+        assert_eq!(array.get_values_f32(), vec![]);
+
+        assert!(array.set_values_f32(&[111.]).is_err());
+        assert!(array.set_values_f32(&[111., 222.]).is_err());
+    }
+
+    #[test]
     fn test_set_values_f32_n() {
         let hw = RefCell::new(CpuHardware::new());
         let mut array = unsafe { Array::raw(&hw, make_shape![3]) };
@@ -538,17 +549,6 @@ mod tests {
         assert!(array.set_values_f32(&[111.]).is_err());
         assert!(array.set_values_f32(&[111., 222.]).is_err());
         assert!(array.set_values_f32(&[111., 222., 333., 444.]).is_err());
-    }
-
-    #[test]
-    fn test_set_values_f32_0() {
-        let hw = RefCell::new(CpuHardware::new());
-        let mut array = unsafe { Array::raw(&hw, make_shape![0]) };
-        array.set_values_f32(&[]).unwrap();
-        assert_eq!(array.get_values_f32(), vec![]);
-
-        assert!(array.set_values_f32(&[111.]).is_err());
-        assert!(array.set_values_f32(&[111., 222.]).is_err());
     }
 
     #[test]
@@ -577,6 +577,22 @@ mod tests {
     }
 
     #[test]
+    fn test_constant_f32_0() {
+        let hw = RefCell::new(CpuHardware::new());
+        let array = Array::constant_f32(&hw, make_shape![0], &[]).unwrap();
+        assert_eq!(array.shape, make_shape![0]);
+        assert!(array.get_scalar_f32().is_err());
+        assert_eq!(array.get_values_f32(), vec![]);
+    }
+
+    #[test]
+    fn test_constant_f32_0_invalid() {
+        let hw = RefCell::new(CpuHardware::new());
+        assert!(Array::constant_f32(&hw, make_shape![0], &[111.]).is_err());
+        assert!(Array::constant_f32(&hw, make_shape![0], &[111., 222.]).is_err());
+    }
+
+    #[test]
     fn test_constant_f32_n() {
         let hw = RefCell::new(CpuHardware::new());
         let array = Array::constant_f32(&hw, make_shape![3], &[123., 456., 789.]).unwrap();
@@ -595,22 +611,6 @@ mod tests {
     }
 
     #[test]
-    fn test_constant_f32_0() {
-        let hw = RefCell::new(CpuHardware::new());
-        let array = Array::constant_f32(&hw, make_shape![0], &[]).unwrap();
-        assert_eq!(array.shape, make_shape![0]);
-        assert!(array.get_scalar_f32().is_err());
-        assert_eq!(array.get_values_f32(), vec![]);
-    }
-
-    #[test]
-    fn test_constant_f32_0_invalid() {
-        let hw = RefCell::new(CpuHardware::new());
-        assert!(Array::constant_f32(&hw, make_shape![0], &[111.]).is_err());
-        assert!(Array::constant_f32(&hw, make_shape![0], &[111., 222.]).is_err());
-    }
-
-    #[test]
     fn test_fill_f32_scalar() {
         let hw = RefCell::new(CpuHardware::new());
         let array = Array::fill_f32(&hw, make_shape![], 123.);
@@ -620,21 +620,21 @@ mod tests {
     }
 
     #[test]
-    fn test_fill_f32_n() {
-        let hw = RefCell::new(CpuHardware::new());
-        let array = Array::fill_f32(&hw, make_shape![3], 123.);
-        assert_eq!(array.shape, make_shape![3]);
-        assert!(array.get_scalar_f32().is_err());
-        assert_eq!(array.get_values_f32(), vec![123., 123., 123.]);
-    }
-
-    #[test]
     fn test_fill_f32_0() {
         let hw = RefCell::new(CpuHardware::new());
         let array = Array::fill_f32(&hw, make_shape![0], 123.);
         assert_eq!(array.shape, make_shape![0]);
         assert!(array.get_scalar_f32().is_err());
         assert_eq!(array.get_values_f32(), vec![]);
+    }
+
+    #[test]
+    fn test_fill_f32_n() {
+        let hw = RefCell::new(CpuHardware::new());
+        let array = Array::fill_f32(&hw, make_shape![3], 123.);
+        assert_eq!(array.shape, make_shape![3]);
+        assert!(array.get_scalar_f32().is_err());
+        assert_eq!(array.get_values_f32(), vec![123., 123., 123.]);
     }
 
     #[test]
@@ -649,17 +649,6 @@ mod tests {
     }
 
     #[test]
-    fn test_fill_colocated_f32_n() {
-        let hw = RefCell::new(CpuHardware::new());
-        let other = unsafe { Array::raw(&hw, make_shape![]) };
-        let array = Array::fill_colocated_f32(&other, make_shape![3], 123.);
-        assert_eq!(array.shape, make_shape![3]);
-        assert!(ptr::eq(array.buffer.hardware(), &hw));
-        assert!(array.get_scalar_f32().is_err());
-        assert_eq!(array.get_values_f32(), vec![123., 123., 123.]);
-    }
-
-    #[test]
     fn test_fill_colocated_f32_0() {
         let hw = RefCell::new(CpuHardware::new());
         let other = unsafe { Array::raw(&hw, make_shape![]) };
@@ -668,6 +657,17 @@ mod tests {
         assert!(ptr::eq(array.buffer.hardware(), &hw));
         assert!(array.get_scalar_f32().is_err());
         assert_eq!(array.get_values_f32(), vec![]);
+    }
+
+    #[test]
+    fn test_fill_colocated_f32_n() {
+        let hw = RefCell::new(CpuHardware::new());
+        let other = unsafe { Array::raw(&hw, make_shape![]) };
+        let array = Array::fill_colocated_f32(&other, make_shape![3], 123.);
+        assert_eq!(array.shape, make_shape![3]);
+        assert!(ptr::eq(array.buffer.hardware(), &hw));
+        assert!(array.get_scalar_f32().is_err());
+        assert_eq!(array.get_values_f32(), vec![123., 123., 123.]);
     }
 
     #[test]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -92,7 +92,7 @@ impl<'hw> Buffer<'hw> {
     ///
     /// # Safety
     ///
-    /// This function returns a raw pointer of the inner memory or a haandle of the associated
+    /// This function returns a raw pointer of the inner memory or a handle of the associated
     /// hardware-specific object.
     /// The value can not be used without knowing the associated hardware.
     pub unsafe fn as_handle(&self) -> *const u8 {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -109,7 +109,7 @@ impl<'hw> Buffer<'hw> {
     ///
     /// This function returns a raw pointer of the inner memory or a handle of the associated
     /// device-specific object.
-    /// The value can not be used without knowing the associated hardware.
+    /// The returned value can not be used without knowing the associated hardware.
     pub unsafe fn as_mut_handle(&mut self) -> *mut u8 {
         self.handle
     }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -107,7 +107,7 @@ impl<'hw> Buffer<'hw> {
     ///
     /// # Safety
     ///
-    /// This function returns a raw pointer of the inner memory or a haandle of the associated
+    /// This function returns a raw pointer of the inner memory or a handle of the associated
     /// device-specific object.
     /// The value can not be used without knowing the associated hardware.
     pub unsafe fn as_mut_handle(&mut self) -> *mut u8 {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -94,7 +94,7 @@ impl<'hw> Buffer<'hw> {
     ///
     /// This function returns a raw pointer of the inner memory or a handle of the associated
     /// hardware-specific object.
-    /// The value can not be used without knowing the associated hardware.
+    /// The returned value can not be used without knowing the associated hardware.
     pub unsafe fn as_handle(&self) -> *const u8 {
         self.handle
     }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -10,7 +10,7 @@ use std::ptr;
 /// At `drop()` the owned handle is released using associated `Hardware`.
 ///
 /// This object can only be alive during the lifetime of the specified hardware.
-pub(crate) struct Buffer<'hw> {
+pub struct Buffer<'hw> {
     /// Reference to the hardware that `pointer` manages.
     hardware: &'hw RefCell<dyn Hardware>,
 
@@ -38,7 +38,7 @@ impl<'hw> Buffer<'hw> {
     /// This function does not initialize the data on the allocated memory, and users are
     /// responsible to initialize the memory immediately by themselves.
     /// Using this object without explicit initialization causes undefined behavior.
-    pub(crate) unsafe fn raw(hardware: &'hw RefCell<dyn Hardware>, size: usize) -> Self {
+    pub unsafe fn raw(hardware: &'hw RefCell<dyn Hardware>, size: usize) -> Self {
         Self {
             hardware,
             size,
@@ -62,7 +62,7 @@ impl<'hw> Buffer<'hw> {
     /// This function does not initialize the data on the allocated memory, and users are
     /// responsible to initialize the memory immediately by themselves.
     /// Using this object without explicit initialization causes undefined behavior.
-    pub(crate) unsafe fn raw_colocated(other: &Self, size: usize) -> Self {
+    pub unsafe fn raw_colocated(other: &Self, size: usize) -> Self {
         Self::raw(other.hardware, size)
     }
 
@@ -71,8 +71,17 @@ impl<'hw> Buffer<'hw> {
     /// # Returns
     ///
     /// A Reference to the wrapped `Hardware` object.
-    pub(crate) fn hardware(&self) -> &'hw RefCell<dyn Hardware> {
+    pub fn hardware(&self) -> &'hw RefCell<dyn Hardware> {
         self.hardware
+    }
+
+    /// Returns the size of the allocated memory.
+    ///
+    /// # Returns
+    ///
+    /// The size of the allocated memory.
+    pub fn size(&self) -> usize {
+        self.size
     }
 
     /// Returns the const handle owned by this buffer.
@@ -80,7 +89,13 @@ impl<'hw> Buffer<'hw> {
     /// # Returns
     ///
     /// Owned handle as a const pointer.
-    pub(crate) unsafe fn as_handle(&self) -> *const u8 {
+    ///
+    /// # Safety
+    ///
+    /// This function returns a raw pointer of the inner memory or a haandle of the associated
+    /// hardware-specific object.
+    /// The value can not be used without knowing the associated hardware.
+    pub unsafe fn as_handle(&self) -> *const u8 {
         self.handle
     }
 
@@ -89,7 +104,13 @@ impl<'hw> Buffer<'hw> {
     /// # Returns
     ///
     /// Owned handle as a mutable pointer.
-    pub(crate) unsafe fn as_mut_handle(&mut self) -> *mut u8 {
+    ///
+    /// # Safety
+    ///
+    /// This function returns a raw pointer of the inner memory or a haandle of the associated
+    /// device-specific object.
+    /// The value can not be used without knowing the associated hardware.
+    pub unsafe fn as_mut_handle(&mut self) -> *mut u8 {
         self.handle
     }
 
@@ -103,7 +124,7 @@ impl<'hw> Buffer<'hw> {
     ///
     /// * `true` - The both buffers are colocated on the same hardware.
     /// * `false` - Otherwise.
-    pub(crate) fn is_colocated(&self, other: &Self) -> bool {
+    pub fn is_colocated(&self, other: &Self) -> bool {
         ptr::eq(self.hardware, other.hardware)
     }
 
@@ -117,7 +138,7 @@ impl<'hw> Buffer<'hw> {
     ///
     /// * `Ok(())` - The both buffers are colocated on the same hardware.
     /// * `Err(Error)` - Otherwise.
-    pub(crate) fn check_colocated(&self, other: &Self) -> Result<()> {
+    pub fn check_colocated(&self, other: &Self) -> Result<()> {
         self.is_colocated(other).then(|| ()).ok_or_else(|| {
             Error::InvalidHardware(format!(
                 "Buffers are not colocated on the same hardware. self: {:p}, other: {:p}",
@@ -207,7 +228,7 @@ mod tests {
         let hw = RefCell::new(CpuHardware::new());
         unsafe {
             let buf = Buffer::raw(&hw, 123);
-            assert_eq!(buf.size, 123);
+            assert_eq!(buf.size(), 123);
         }
     }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -7,11 +7,19 @@ use crate::shape::Shape;
 /// Placeholder of `Array`s.
 /// Unlike `Option`, the object always holds its `Shape` informatin.
 pub(crate) enum ArrayPlaceholder<'hw> {
+    /// `Array` is not assigned, while its `Shape` is known.
     Unassigned(Shape),
+
+    /// `Array` is assigned.
     Assigned(Array<'hw>),
 }
 
 impl<'hw> ArrayPlaceholder<'hw> {
+    /// Obtains the `Shape` of this placeholder.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the inner `Shape` object.
     pub(crate) fn shape(&self) -> &Shape {
         match self {
             Self::Unassigned(ref shape) => shape,
@@ -19,6 +27,12 @@ impl<'hw> ArrayPlaceholder<'hw> {
         }
     }
 
+    /// Obtains the `Array` if the placeholder holds it.
+    ///
+    /// # Returns
+    ///
+    /// * `Some(&Array)` - A reference to the inner `Array` object.
+    /// * `None` - The placeholder does not hold the `Array` object.
     pub(crate) fn array(&self) -> Option<&Array<'hw>> {
         match self {
             Self::Unassigned(_) => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
-mod array;
-mod buffer;
-mod error;
+pub mod array;
+pub mod buffer;
+pub mod error;
 mod graph;
 pub mod hardware;
 pub mod node;
 mod operator;
-mod result;
+pub mod result;
 pub mod shape;

--- a/src/node.rs
+++ b/src/node.rs
@@ -4,6 +4,7 @@ use crate::graph::Graph;
 use crate::hardware::Hardware;
 use crate::operator;
 use crate::result::Result;
+use crate::shape::Shape;
 use std::cell::RefCell;
 use std::fmt;
 use std::ptr;
@@ -61,6 +62,16 @@ impl<'hw: 'op, 'op: 'g, 'g> Node<'hw, 'op, 'g> {
                     "Attempted calculation between Nodes on different Graph.".to_string(),
                 )
             })
+    }
+
+    pub fn shape(&self) -> Shape {
+        self.graph
+            .borrow()
+            .get_step(self.step_id)
+            .unwrap()
+            .output
+            .shape()
+            .clone()
     }
 
     pub fn calculate(&self) -> Result<Array<'hw>> {
@@ -219,6 +230,10 @@ mod tests {
         let rhs = Node::from_scalar(&hw, &g, 2.);
         let ret = lhs + rhs;
 
+        assert_eq!(lhs.shape(), make_shape![]);
+        assert_eq!(rhs.shape(), make_shape![]);
+        assert_eq!(ret.shape(), make_shape![]);
+
         {
             let g = g.borrow();
             assert_eq!(g.num_steps(), 3);
@@ -243,6 +258,10 @@ mod tests {
 
         let src = Node::from_scalar(&hw, &g, 42.);
         let dest = -src;
+
+        assert_eq!(src.shape(), make_shape![]);
+        assert_eq!(dest.shape(), make_shape![]);
+
         assert_eq!(dest.calculate().unwrap().to_scalar(), Ok(-42.));
     }
 
@@ -254,6 +273,11 @@ mod tests {
         let lhs = Node::from_scalar(&hw, &g, 1.);
         let rhs = Node::from_scalar(&hw, &g, 2.);
         let ret = lhs + rhs;
+
+        assert_eq!(lhs.shape(), make_shape![]);
+        assert_eq!(rhs.shape(), make_shape![]);
+        assert_eq!(ret.shape(), make_shape![]);
+
         assert_eq!(ret.calculate().unwrap().to_scalar(), Ok(3.));
     }
 
@@ -265,6 +289,11 @@ mod tests {
         let lhs = Node::from_scalar(&hw, &g, 1.);
         let rhs = Node::from_scalar(&hw, &g, 2.);
         let ret = lhs - rhs;
+
+        assert_eq!(lhs.shape(), make_shape![]);
+        assert_eq!(rhs.shape(), make_shape![]);
+        assert_eq!(ret.shape(), make_shape![]);
+
         assert_eq!(ret.calculate().unwrap().to_scalar(), Ok(-1.));
     }
 
@@ -276,6 +305,11 @@ mod tests {
         let lhs = Node::from_scalar(&hw, &g, 1.);
         let rhs = Node::from_scalar(&hw, &g, 2.);
         let ret = lhs * rhs;
+
+        assert_eq!(lhs.shape(), make_shape![]);
+        assert_eq!(rhs.shape(), make_shape![]);
+        assert_eq!(ret.shape(), make_shape![]);
+
         assert_eq!(ret.calculate().unwrap().to_scalar(), Ok(2.));
     }
 
@@ -287,6 +321,11 @@ mod tests {
         let lhs = Node::from_scalar(&hw, &g, 1.);
         let rhs = Node::from_scalar(&hw, &g, 2.);
         let ret = lhs / rhs;
+
+        assert_eq!(lhs.shape(), make_shape![]);
+        assert_eq!(rhs.shape(), make_shape![]);
+        assert_eq!(ret.shape(), make_shape![]);
+
         assert_eq!(ret.calculate().unwrap().to_scalar(), Ok(0.5));
     }
 
@@ -299,6 +338,12 @@ mod tests {
         let b = Node::from_scalar(&hw, &g, 2.);
         let c = Node::from_scalar(&hw, &g, 3.);
         let y = a + -b * c;
+
+        assert_eq!(a.shape(), make_shape![]);
+        assert_eq!(b.shape(), make_shape![]);
+        assert_eq!(c.shape(), make_shape![]);
+        assert_eq!(y.shape(), make_shape![]);
+
         assert_eq!(y.calculate().unwrap().to_scalar(), Ok(-5.));
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -34,7 +34,7 @@ impl<'hw: 'op, 'op: 'g, 'g> Node<'hw, 'op, 'g> {
             graph
                 .borrow_mut()
                 .add_step(
-                    Box::new(operator::constant::Constant::new(Array::new_scalar(
+                    Box::new(operator::constant::Constant::new(Array::scalar_f32(
                         hardware, value,
                     ))),
                     vec![],
@@ -48,7 +48,7 @@ impl<'hw: 'op, 'op: 'g, 'g> Node<'hw, 'op, 'g> {
             .borrow_mut()
             .calculate(self.step_id)
             .unwrap()
-            .to_scalar()
+            .get_scalar_f32()
             .unwrap()
     }
 
@@ -248,7 +248,7 @@ mod tests {
 
         let retval = ret.calculate().unwrap();
         assert_eq!(*retval.shape(), make_shape![]);
-        assert_eq!(retval.to_scalar(), Ok(3.));
+        assert_eq!(retval.get_scalar_f32(), Ok(3.));
     }
 
     #[test]
@@ -262,7 +262,7 @@ mod tests {
         assert_eq!(src.shape(), make_shape![]);
         assert_eq!(dest.shape(), make_shape![]);
 
-        assert_eq!(dest.calculate().unwrap().to_scalar(), Ok(-42.));
+        assert_eq!(dest.calculate().unwrap().get_scalar_f32(), Ok(-42.));
     }
 
     #[test]
@@ -278,7 +278,7 @@ mod tests {
         assert_eq!(rhs.shape(), make_shape![]);
         assert_eq!(ret.shape(), make_shape![]);
 
-        assert_eq!(ret.calculate().unwrap().to_scalar(), Ok(3.));
+        assert_eq!(ret.calculate().unwrap().get_scalar_f32(), Ok(3.));
     }
 
     #[test]
@@ -294,7 +294,7 @@ mod tests {
         assert_eq!(rhs.shape(), make_shape![]);
         assert_eq!(ret.shape(), make_shape![]);
 
-        assert_eq!(ret.calculate().unwrap().to_scalar(), Ok(-1.));
+        assert_eq!(ret.calculate().unwrap().get_scalar_f32(), Ok(-1.));
     }
 
     #[test]
@@ -310,7 +310,7 @@ mod tests {
         assert_eq!(rhs.shape(), make_shape![]);
         assert_eq!(ret.shape(), make_shape![]);
 
-        assert_eq!(ret.calculate().unwrap().to_scalar(), Ok(2.));
+        assert_eq!(ret.calculate().unwrap().get_scalar_f32(), Ok(2.));
     }
 
     #[test]
@@ -326,7 +326,7 @@ mod tests {
         assert_eq!(rhs.shape(), make_shape![]);
         assert_eq!(ret.shape(), make_shape![]);
 
-        assert_eq!(ret.calculate().unwrap().to_scalar(), Ok(0.5));
+        assert_eq!(ret.calculate().unwrap().get_scalar_f32(), Ok(0.5));
     }
 
     #[test]
@@ -344,6 +344,6 @@ mod tests {
         assert_eq!(c.shape(), make_shape![]);
         assert_eq!(y.shape(), make_shape![]);
 
-        assert_eq!(y.calculate().unwrap().to_scalar(), Ok(-5.));
+        assert_eq!(y.calculate().unwrap().get_scalar_f32(), Ok(-5.));
     }
 }

--- a/src/operator/add.rs
+++ b/src/operator/add.rs
@@ -56,10 +56,10 @@ mod tests {
         let op = Add::new();
         assert_eq!(op.name(), "Add");
         assert_eq!(op.input_size(), 2);
-        let inputs = vec![Array::new_scalar(&hw, 1.), Array::new_scalar(&hw, 2.)];
-        let expected = Array::new_scalar(&hw, 3.);
+        let inputs = vec![Array::scalar_f32(&hw, 1.), Array::scalar_f32(&hw, 2.)];
+        let expected = Array::scalar_f32(&hw, 3.);
         let observed = op.perform(&inputs.iter().collect::<Vec<_>>()).unwrap();
         assert_eq!(observed.shape(), expected.shape());
-        assert_eq!(observed.to_scalar(), expected.to_scalar());
+        assert_eq!(observed.get_scalar_f32(), expected.get_scalar_f32());
     }
 }

--- a/src/operator/constant.rs
+++ b/src/operator/constant.rs
@@ -42,13 +42,13 @@ mod tests {
     #[test]
     fn test_constant_op() {
         let hw = RefCell::new(CpuHardware::new());
-        let op = Constant::new(Array::new_scalar(&hw, 123.));
+        let op = Constant::new(Array::scalar_f32(&hw, 123.));
         assert_eq!(op.name(), "Constant");
         assert_eq!(op.input_size(), 0);
         let input_refs = vec![];
-        let expected = Array::new_scalar(&hw, 123.);
+        let expected = Array::scalar_f32(&hw, 123.);
         let observed = op.perform(&input_refs).unwrap();
         assert_eq!(observed.shape(), expected.shape());
-        assert_eq!(observed.to_scalar(), expected.to_scalar());
+        assert_eq!(observed.get_scalar_f32(), expected.get_scalar_f32());
     }
 }

--- a/src/operator/div.rs
+++ b/src/operator/div.rs
@@ -57,10 +57,10 @@ mod tests {
         let op = Div::new();
         assert_eq!(op.name(), "Div");
         assert_eq!(op.input_size(), 2);
-        let inputs = vec![Array::new_scalar(&hw, 1.), Array::new_scalar(&hw, 2.)];
-        let expected = Array::new_scalar(&hw, 0.5);
+        let inputs = vec![Array::scalar_f32(&hw, 1.), Array::scalar_f32(&hw, 2.)];
+        let expected = Array::scalar_f32(&hw, 0.5);
         let observed = op.perform(&inputs.iter().collect::<Vec<_>>()).unwrap();
         assert_eq!(observed.shape(), expected.shape());
-        assert_eq!(observed.to_scalar(), expected.to_scalar());
+        assert_eq!(observed.get_scalar_f32(), expected.get_scalar_f32());
     }
 }

--- a/src/operator/mul.rs
+++ b/src/operator/mul.rs
@@ -56,10 +56,10 @@ mod tests {
         let op = Mul::new();
         assert_eq!(op.name(), "Mul");
         assert_eq!(op.input_size(), 2);
-        let inputs = vec![Array::new_scalar(&hw, 1.), Array::new_scalar(&hw, 2.)];
-        let expected = Array::new_scalar(&hw, 2.);
+        let inputs = vec![Array::scalar_f32(&hw, 1.), Array::scalar_f32(&hw, 2.)];
+        let expected = Array::scalar_f32(&hw, 2.);
         let observed = op.perform(&inputs.iter().collect::<Vec<_>>()).unwrap();
         assert_eq!(observed.shape(), expected.shape());
-        assert_eq!(observed.to_scalar(), expected.to_scalar());
+        assert_eq!(observed.get_scalar_f32(), expected.get_scalar_f32());
     }
 }

--- a/src/operator/neg.rs
+++ b/src/operator/neg.rs
@@ -26,7 +26,7 @@ impl<'hw> Operator<'hw> for Neg {
     }
 
     fn perform(&self, inputs: &[&Array<'hw>]) -> Result<Array<'hw>> {
-        inputs[0].elementwise_neg_f32()
+        Ok(inputs[0].elementwise_neg_f32())
     }
 
     fn gradient<'op: 'g, 'g>(
@@ -56,10 +56,10 @@ mod tests {
         let op = Neg::new();
         assert_eq!(op.name(), "Neg");
         assert_eq!(op.input_size(), 1);
-        let inputs = vec![Array::new_scalar(&hw, 42.)];
-        let expected = Array::new_scalar(&hw, -42.);
+        let inputs = vec![Array::scalar_f32(&hw, 42.)];
+        let expected = Array::scalar_f32(&hw, -42.);
         let observed = op.perform(&inputs.iter().collect::<Vec<_>>()).unwrap();
         assert_eq!(observed.shape(), expected.shape());
-        assert_eq!(observed.to_scalar(), expected.to_scalar());
+        assert_eq!(observed.get_scalar_f32(), expected.get_scalar_f32());
     }
 }

--- a/src/operator/sub.rs
+++ b/src/operator/sub.rs
@@ -56,10 +56,10 @@ mod tests {
         let op = Sub::new();
         assert_eq!(op.name(), "Sub");
         assert_eq!(op.input_size(), 2);
-        let inputs = vec![Array::new_scalar(&hw, 1.), Array::new_scalar(&hw, 2.)];
-        let expected = Array::new_scalar(&hw, -1.);
+        let inputs = vec![Array::scalar_f32(&hw, 1.), Array::scalar_f32(&hw, 2.)];
+        let expected = Array::scalar_f32(&hw, -1.);
         let observed = op.perform(&inputs.iter().collect::<Vec<_>>()).unwrap();
         assert_eq!(observed.shape(), expected.shape());
-        assert_eq!(observed.to_scalar(), expected.to_scalar());
+        assert_eq!(observed.get_scalar_f32(), expected.get_scalar_f32());
     }
 }


### PR DESCRIPTION
This change involves some broad changes about `Array`'s interface:

- Rename some functions to  consolidate naming of getter/setters.
- Add functionality to get/set all values.
- Add fill function.
- Changes some return types.
- Add detailed tests.