### PR TITLE
Refactor Operator

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -71,10 +71,17 @@ impl<'hw> Array<'hw> {
     /// # Returns
     ///
     /// Reference to the `Shape` object.
-    ///
-    /// Shape of the array.
     pub fn shape(&self) -> &Shape {
         &self.shape
+    }
+
+    /// Returns the hardware of the array.
+    ///
+    /// # Returns
+    ///
+    /// Reference to the `Hardware` object.
+    pub fn hardware(&self) -> &'hw RefCell<dyn Hardware> {
+        self.buffer.hardware()
     }
 
     /// Sets a scalar value to this array.
@@ -90,7 +97,7 @@ impl<'hw> Array<'hw> {
     pub fn set_scalar_f32(&mut self, value: f32) -> Result<()> {
         self.shape.check_is_scalar()?;
         unsafe {
-            self.buffer.hardware().borrow_mut().copy_host_to_hardware(
+            self.hardware().borrow_mut().copy_host_to_hardware(
                 (&value as *const f32) as *const u8,
                 self.buffer.as_mut_handle(),
                 mem::size_of::<f32>(),
@@ -113,7 +120,7 @@ impl<'hw> Array<'hw> {
         self.shape.check_is_scalar()?;
         let mut value = 0.;
         unsafe {
-            self.buffer.hardware().borrow_mut().copy_hardware_to_host(
+            self.hardware().borrow_mut().copy_hardware_to_host(
                 self.buffer.as_handle(),
                 (&mut value as *mut f32) as *mut u8,
                 mem::size_of::<f32>(),
@@ -144,7 +151,7 @@ impl<'hw> Array<'hw> {
         }
 
         unsafe {
-            self.buffer.hardware().borrow_mut().copy_host_to_hardware(
+            self.hardware().borrow_mut().copy_host_to_hardware(
                 values.as_ptr() as *const u8,
                 self.buffer.as_mut_handle(),
                 self.shape.num_elements() * mem::size_of::<f32>(),
@@ -163,7 +170,7 @@ impl<'hw> Array<'hw> {
         let num_elements = self.shape.num_elements();
         let mut values = Vec::<f32>::with_capacity(num_elements);
         unsafe {
-            self.buffer.hardware().borrow_mut().copy_hardware_to_host(
+            self.hardware().borrow_mut().copy_hardware_to_host(
                 self.buffer.as_handle(),
                 values.as_mut_ptr() as *mut u8,
                 num_elements * mem::size_of::<f32>(),
@@ -249,7 +256,7 @@ impl<'hw> Array<'hw> {
     /// * `Ok(Array)` - A new `Array` object.
     /// * `Err(Error)` - Some error occurred during the process.
     pub fn fill_colocated_f32(other: &Self, shape: Shape, value: f32) -> Self {
-        Self::fill_f32(other.buffer.hardware(), shape, value)
+        Self::fill_f32(other.hardware(), shape, value)
     }
 
     /// Performs elementwise negation operation and returns a new `Array` of resulting
@@ -264,7 +271,7 @@ impl<'hw> Array<'hw> {
     pub fn elementwise_neg_f32(&self) -> Self {
         unsafe {
             let mut output = Self::raw_colocated(self, self.shape.clone());
-            output.buffer.hardware().borrow_mut().elementwise_neg_f32(
+            output.hardware().borrow_mut().elementwise_neg_f32(
                 self.buffer.as_handle(),
                 output.buffer.as_mut_handle(),
                 self.shape.num_elements(),
@@ -291,7 +298,7 @@ impl<'hw> Array<'hw> {
         let num_elements = output_shape.num_elements();
         unsafe {
             let mut output = Self::raw_colocated(self, output_shape);
-            output.buffer.hardware().borrow_mut().elementwise_add_f32(
+            output.hardware().borrow_mut().elementwise_add_f32(
                 self.buffer.as_handle(),
                 other.buffer.as_handle(),
                 output.buffer.as_mut_handle(),
@@ -319,7 +326,7 @@ impl<'hw> Array<'hw> {
         let num_elements = output_shape.num_elements();
         unsafe {
             let mut output = Self::raw_colocated(self, output_shape);
-            output.buffer.hardware().borrow_mut().elementwise_sub_f32(
+            output.hardware().borrow_mut().elementwise_sub_f32(
                 self.buffer.as_handle(),
                 other.buffer.as_handle(),
                 output.buffer.as_mut_handle(),
@@ -347,7 +354,7 @@ impl<'hw> Array<'hw> {
         let num_elements = output_shape.num_elements();
         unsafe {
             let mut output = Self::raw_colocated(self, output_shape);
-            output.buffer.hardware().borrow_mut().elementwise_mul_f32(
+            output.hardware().borrow_mut().elementwise_mul_f32(
                 self.buffer.as_handle(),
                 other.buffer.as_handle(),
                 output.buffer.as_mut_handle(),
@@ -375,7 +382,7 @@ impl<'hw> Array<'hw> {
         let num_elements = output_shape.num_elements();
         unsafe {
             let mut output = Self::raw_colocated(self, output_shape);
-            output.buffer.hardware().borrow_mut().elementwise_div_f32(
+            output.hardware().borrow_mut().elementwise_div_f32(
                 self.buffer.as_handle(),
                 other.buffer.as_handle(),
                 output.buffer.as_mut_handle(),

--- a/src/array/tests.rs
+++ b/src/array/tests.rs
@@ -1,8 +1,6 @@
-use crate::array::Array;
+use crate::array::*;
 use crate::hardware::cpu::CpuHardware;
-use crate::make_shape;
-use std::cell::RefCell;
-use std::mem::size_of;
+use std::mem;
 use std::ptr;
 
 #[test]
@@ -10,7 +8,7 @@ fn test_raw_scalar() {
     let hw = RefCell::new(CpuHardware::new());
     let array = unsafe { Array::raw(&hw, make_shape![]) };
     assert!(ptr::eq(array.hardware(), &hw));
-    assert_eq!(array.buffer.size(), size_of::<f32>());
+    assert_eq!(array.buffer.size(), mem::size_of::<f32>());
     assert_eq!(array.shape, make_shape![]);
 }
 
@@ -28,7 +26,7 @@ fn test_raw_n() {
     let hw = RefCell::new(CpuHardware::new());
     let array = unsafe { Array::raw(&hw, make_shape![42]) };
     assert!(ptr::eq(array.hardware(), &hw));
-    assert_eq!(array.buffer.size(), 42 * size_of::<f32>());
+    assert_eq!(array.buffer.size(), 42 * mem::size_of::<f32>());
     assert_eq!(array.shape, make_shape![42]);
 }
 
@@ -38,7 +36,7 @@ fn test_raw_colocated_scalar() {
     let other = unsafe { Array::raw(&hw, make_shape![]) };
     let colocated = unsafe { Array::raw_colocated(&other, make_shape![]) };
     assert!(ptr::eq(colocated.hardware(), &hw));
-    assert_eq!(colocated.buffer.size(), size_of::<f32>());
+    assert_eq!(colocated.buffer.size(), mem::size_of::<f32>());
     assert_eq!(colocated.shape, make_shape![]);
 }
 
@@ -58,7 +56,7 @@ fn test_raw_colocated_n() {
     let other = unsafe { Array::raw(&hw, make_shape![]) };
     let colocated = unsafe { Array::raw_colocated(&other, make_shape![42]) };
     assert!(ptr::eq(colocated.hardware(), &hw));
-    assert_eq!(colocated.buffer.size(), 42 * size_of::<f32>());
+    assert_eq!(colocated.buffer.size(), 42 * mem::size_of::<f32>());
     assert_eq!(colocated.shape, make_shape![42]);
 }
 

--- a/src/array/tests.rs
+++ b/src/array/tests.rs
@@ -9,7 +9,7 @@ use std::ptr;
 fn test_raw_scalar() {
     let hw = RefCell::new(CpuHardware::new());
     let array = unsafe { Array::raw(&hw, make_shape![]) };
-    assert!(ptr::eq(array.buffer.hardware(), &hw));
+    assert!(ptr::eq(array.hardware(), &hw));
     assert_eq!(array.buffer.size(), size_of::<f32>());
     assert_eq!(array.shape, make_shape![]);
 }
@@ -18,7 +18,7 @@ fn test_raw_scalar() {
 fn test_raw_0() {
     let hw = RefCell::new(CpuHardware::new());
     let array = unsafe { Array::raw(&hw, make_shape![0]) };
-    assert!(ptr::eq(array.buffer.hardware(), &hw));
+    assert!(ptr::eq(array.hardware(), &hw));
     assert_eq!(array.buffer.size(), 0);
     assert_eq!(array.shape, make_shape![0]);
 }
@@ -27,7 +27,7 @@ fn test_raw_0() {
 fn test_raw_n() {
     let hw = RefCell::new(CpuHardware::new());
     let array = unsafe { Array::raw(&hw, make_shape![42]) };
-    assert!(ptr::eq(array.buffer.hardware(), &hw));
+    assert!(ptr::eq(array.hardware(), &hw));
     assert_eq!(array.buffer.size(), 42 * size_of::<f32>());
     assert_eq!(array.shape, make_shape![42]);
 }
@@ -37,7 +37,7 @@ fn test_raw_colocated_scalar() {
     let hw = RefCell::new(CpuHardware::new());
     let other = unsafe { Array::raw(&hw, make_shape![]) };
     let colocated = unsafe { Array::raw_colocated(&other, make_shape![]) };
-    assert!(ptr::eq(colocated.buffer.hardware(), &hw));
+    assert!(ptr::eq(colocated.hardware(), &hw));
     assert_eq!(colocated.buffer.size(), size_of::<f32>());
     assert_eq!(colocated.shape, make_shape![]);
 }
@@ -47,7 +47,7 @@ fn test_raw_colocated_0() {
     let hw = RefCell::new(CpuHardware::new());
     let other = unsafe { Array::raw(&hw, make_shape![]) };
     let colocated = unsafe { Array::raw_colocated(&other, make_shape![0]) };
-    assert!(ptr::eq(colocated.buffer.hardware(), &hw));
+    assert!(ptr::eq(colocated.hardware(), &hw));
     assert_eq!(colocated.buffer.size(), 0);
     assert_eq!(colocated.shape, make_shape![0]);
 }
@@ -57,7 +57,7 @@ fn test_raw_colocated_n() {
     let hw = RefCell::new(CpuHardware::new());
     let other = unsafe { Array::raw(&hw, make_shape![]) };
     let colocated = unsafe { Array::raw_colocated(&other, make_shape![42]) };
-    assert!(ptr::eq(colocated.buffer.hardware(), &hw));
+    assert!(ptr::eq(colocated.hardware(), &hw));
     assert_eq!(colocated.buffer.size(), 42 * size_of::<f32>());
     assert_eq!(colocated.shape, make_shape![42]);
 }
@@ -235,7 +235,7 @@ fn test_fill_colocated_f32_scalar() {
     let other = unsafe { Array::raw(&hw, make_shape![]) };
     let array = Array::fill_colocated_f32(&other, make_shape![], 123.);
     assert_eq!(array.shape, make_shape![]);
-    assert!(ptr::eq(array.buffer.hardware(), &hw));
+    assert!(ptr::eq(array.hardware(), &hw));
     assert_eq!(array.get_scalar_f32(), Ok(123.));
     assert_eq!(array.get_values_f32(), vec![123.]);
 }
@@ -246,7 +246,7 @@ fn test_fill_colocated_f32_0() {
     let other = unsafe { Array::raw(&hw, make_shape![]) };
     let array = Array::fill_colocated_f32(&other, make_shape![0], 123.);
     assert_eq!(array.shape, make_shape![0]);
-    assert!(ptr::eq(array.buffer.hardware(), &hw));
+    assert!(ptr::eq(array.hardware(), &hw));
     assert!(array.get_scalar_f32().is_err());
     assert_eq!(array.get_values_f32(), vec![]);
 }
@@ -257,7 +257,7 @@ fn test_fill_colocated_f32_n() {
     let other = unsafe { Array::raw(&hw, make_shape![]) };
     let array = Array::fill_colocated_f32(&other, make_shape![3], 123.);
     assert_eq!(array.shape, make_shape![3]);
-    assert!(ptr::eq(array.buffer.hardware(), &hw));
+    assert!(ptr::eq(array.hardware(), &hw));
     assert!(array.get_scalar_f32().is_err());
     assert_eq!(array.get_values_f32(), vec![123., 123., 123.]);
 }
@@ -269,7 +269,7 @@ fn test_elementwise_unary_f32_scalar() {
 
     let y = x.elementwise_neg_f32();
     assert_eq!(y.shape, make_shape![]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![-123.]);
 }
 
@@ -280,7 +280,7 @@ fn test_elementwise_unary_f32_0() {
 
     let y = x.elementwise_neg_f32();
     assert_eq!(y.shape, make_shape![0]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![]);
 }
 
@@ -291,7 +291,7 @@ fn test_elementwise_unary_f32_n() {
 
     let y = x.elementwise_neg_f32();
     assert_eq!(y.shape, make_shape![3]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![-123., -456., -789.]);
 }
 
@@ -303,22 +303,22 @@ fn test_elementwise_binary_f32_scalar_scalar() {
 
     let y = a.elementwise_add_f32(&b).unwrap();
     assert_eq!(y.shape, make_shape![]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![333.]);
 
     let y = a.elementwise_sub_f32(&b).unwrap();
     assert_eq!(y.shape, make_shape![]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![-111.]);
 
     let y = a.elementwise_mul_f32(&b).unwrap();
     assert_eq!(y.shape, make_shape![]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![24642.]);
 
     let y = a.elementwise_div_f32(&b).unwrap();
     assert_eq!(y.shape, make_shape![]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![0.5]);
 }
 
@@ -329,22 +329,22 @@ fn test_elementwise_binary_f32_scalar_self() {
 
     let y = a.elementwise_add_f32(&a).unwrap();
     assert_eq!(y.shape, make_shape![]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![222.]);
 
     let y = a.elementwise_sub_f32(&a).unwrap();
     assert_eq!(y.shape, make_shape![]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![0.]);
 
     let y = a.elementwise_mul_f32(&a).unwrap();
     assert_eq!(y.shape, make_shape![]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![12321.]);
 
     let y = a.elementwise_div_f32(&a).unwrap();
     assert_eq!(y.shape, make_shape![]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![1.]);
 }
 
@@ -356,22 +356,22 @@ fn test_elementwise_binary_f32_0_0() {
 
     let y = a.elementwise_add_f32(&b).unwrap();
     assert_eq!(y.shape, make_shape![0]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![]);
 
     let y = a.elementwise_sub_f32(&b).unwrap();
     assert_eq!(y.shape, make_shape![0]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![]);
 
     let y = a.elementwise_mul_f32(&b).unwrap();
     assert_eq!(y.shape, make_shape![0]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![]);
 
     let y = a.elementwise_div_f32(&b).unwrap();
     assert_eq!(y.shape, make_shape![0]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![]);
 }
 
@@ -382,22 +382,22 @@ fn test_elementwise_binary_f32_0_self() {
 
     let y = a.elementwise_add_f32(&a).unwrap();
     assert_eq!(y.shape, make_shape![0]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![]);
 
     let y = a.elementwise_sub_f32(&a).unwrap();
     assert_eq!(y.shape, make_shape![0]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![]);
 
     let y = a.elementwise_mul_f32(&a).unwrap();
     assert_eq!(y.shape, make_shape![0]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![]);
 
     let y = a.elementwise_div_f32(&a).unwrap();
     assert_eq!(y.shape, make_shape![0]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![]);
 }
 
@@ -409,22 +409,22 @@ fn test_elementwise_binary_f32_n_n() {
 
     let y = a.elementwise_add_f32(&b).unwrap();
     assert_eq!(y.shape, make_shape![3]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![555., 777., 999.]);
 
     let y = a.elementwise_sub_f32(&b).unwrap();
     assert_eq!(y.shape, make_shape![3]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![-333., -333., -333.]);
 
     let y = a.elementwise_mul_f32(&b).unwrap();
     assert_eq!(y.shape, make_shape![3]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![49284., 123210., 221778.]);
 
     let y = a.elementwise_div_f32(&b).unwrap();
     assert_eq!(y.shape, make_shape![3]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     // Attempting exact matching even for 0.4.
     assert_eq!(y.get_values_f32(), vec![0.25, 0.4, 0.5]);
 }
@@ -436,22 +436,22 @@ fn test_elementwise_binary_f32_n_self() {
 
     let y = a.elementwise_add_f32(&a).unwrap();
     assert_eq!(y.shape, make_shape![3]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![222., 444., 666.]);
 
     let y = a.elementwise_sub_f32(&a).unwrap();
     assert_eq!(y.shape, make_shape![3]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![0., 0., 0.]);
 
     let y = a.elementwise_mul_f32(&a).unwrap();
     assert_eq!(y.shape, make_shape![3]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![12321., 49284., 110889.]);
 
     let y = a.elementwise_div_f32(&a).unwrap();
     assert_eq!(y.shape, make_shape![3]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![1., 1., 1.]);
 }
 
@@ -581,7 +581,7 @@ fn test_clone_scalar() {
     let x = Array::scalar_f32(&hw, 123.);
     let y = x.clone();
     assert_eq!(y.shape, make_shape![]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![123.]);
 }
 
@@ -591,7 +591,7 @@ fn test_clone_0() {
     let x = Array::constant_f32(&hw, make_shape![0], &[]).unwrap();
     let y = x.clone();
     assert_eq!(y.shape, make_shape![0]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![]);
 }
 
@@ -601,6 +601,6 @@ fn test_clone_n() {
     let x = Array::constant_f32(&hw, make_shape![3], &[123., 456., 789.]).unwrap();
     let y = x.clone();
     assert_eq!(y.shape, make_shape![3]);
-    assert!(ptr::eq(y.buffer.hardware(), &hw));
+    assert!(ptr::eq(y.hardware(), &hw));
     assert_eq!(y.get_values_f32(), vec![123., 456., 789.]);
 }

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -9,10 +9,46 @@ use std::ptr;
 
 /// Operator represents an individual computation process in the computation graph.
 pub(crate) trait Operator<'hw> {
+    /// Returns the name of the operator.
+    ///
+    /// # Returns
+    ///
+    /// The name of the operator.
     fn name(&self) -> String;
+
+    /// Returns the number of required inputs.
+    ///
+    /// # Returns
+    ///
+    /// The number of required inputs.
     fn input_size(&self) -> usize;
+
+    /// Calculates the output shape.
+    /// This function may be called before `perform()` to propagate `Node` information.
+    ///
+    /// # Arguments
+    ///
+    /// * `inputs` - Input shapes. The number of elements must be the same as the return value of
+    ///   `input_size()`.
+    ///
+    /// # Returns:
+    ///
+    /// * `Ok(Shape)` - The output shape.
+    /// * `Err(Error)` - Some error occurred during the process.
     fn perform_shape(&self, inputs: &[&Shape]) -> Result<Shape>;
 
+    /// Calculates the output hardware.
+    /// This function may be called before `perform()` to propagate `Node` information.
+    ///
+    /// # Arguments
+    ///
+    /// * `inputs` - Input hardwares. The number of elements must be the same as the return value
+    ///   of `input_size()`.
+    ///
+    /// # Returns:
+    ///
+    /// * `Ok(&RefCell<dyn Hardware>)` - The output hardware.
+    /// * `Err(Error)` - Some error occurred during the process.
     fn perform_hardware(
         &self,
         inputs: &[&'hw RefCell<dyn Hardware>],
@@ -36,8 +72,36 @@ pub(crate) trait Operator<'hw> {
         }
     }
 
+    /// Calculates the output array.
+    ///
+    /// # Arguments
+    ///
+    /// * `inputs` - Input arrays. The number of elements must be the same as the return value of
+    ///   `input_size()`.
+    ///
+    /// # Returns:
+    ///
+    /// * `Ok(Array)` - The ouptut array.
+    /// * `Err(Error)` - Some error occurred during the process.
     fn perform(&self, inputs: &[&Array<'hw>]) -> Result<Array<'hw>>;
 
+    /// Constructs the gradient graph.
+    ///
+    /// # Arguments:
+    ///
+    /// * `x` - `Node`s of input values. The number of elements must be the same as the return
+    ///   value of `input_size()`.
+    /// * `y` - `Node` of the output value.
+    /// * `gy` - `Node` of the gradient for `y`: df/dy. The target value "f" depends on the
+    ///   context when this function is called.
+    ///
+    /// # Returns:
+    ///
+    /// List of `Node`s of the gradient for `x[i]`: df/dx[i]. The number of elements must be the
+    /// same as the return value of `input_size()`.
+    /// Resulting nodes usually represent gy * dy/dx[i] according to the chain rule of derivatives,
+    /// but operators can implement other calculation instead for representing unusual gradient
+    /// manipulations.
     fn gradient<'op: 'g, 'g>(
         &self,
         _x: &[Node<'hw, 'op, 'g>],

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -1,15 +1,43 @@
 use crate::array::Array;
 use crate::error::Error;
+use crate::hardware::Hardware;
 use crate::node::Node;
 use crate::result::Result;
 use crate::shape::Shape;
+use std::cell::RefCell;
+use std::ptr;
 
 /// Operator represents an individual computation process in the computation graph.
 pub(crate) trait Operator<'hw> {
     fn name(&self) -> String;
     fn input_size(&self) -> usize;
     fn perform_shape(&self, inputs: &[&Shape]) -> Result<Shape>;
+
+    fn perform_hardware(
+        &self,
+        inputs: &[&'hw RefCell<dyn Hardware>],
+    ) -> Result<&'hw RefCell<dyn Hardware>> {
+        // Most operations assumes that all inputs are on the same hardware.
+        if self.input_size() > 0 {
+            let hw = inputs[0];
+            if inputs.iter().skip(1).all(|&x| ptr::eq(hw, x)) {
+                Ok(hw)
+            } else {
+                Err(Error::InvalidNode(format!(
+                    "{} does not support operations between different hardwares.",
+                    self.name()
+                )))
+            }
+        } else {
+            Err(Error::NotSupported(format!(
+                "No hardware propagation for {}",
+                self.name()
+            )))
+        }
+    }
+
     fn perform(&self, inputs: &[&Array<'hw>]) -> Result<Array<'hw>>;
+
     fn gradient<'op: 'g, 'g>(
         &self,
         _x: &[Node<'hw, 'op, 'g>],

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -17,7 +17,7 @@ pub(crate) trait Operator<'hw> {
         &self,
         inputs: &[&'hw RefCell<dyn Hardware>],
     ) -> Result<&'hw RefCell<dyn Hardware>> {
-        // Most operations assumes that all inputs are on the same hardware.
+        // Most operations assume that all inputs are on the same hardware.
         if self.input_size() > 0 {
             let hw = inputs[0];
             if inputs.iter().skip(1).all(|&x| ptr::eq(hw, x)) {

--- a/src/operator/add.rs
+++ b/src/operator/add.rs
@@ -54,9 +54,10 @@ mod tests {
     fn test_perform() {
         let hw = RefCell::new(CpuHardware::new());
         let op = Add::new();
-        let inputs = vec![Array::scalar_f32(&hw, 1.), Array::scalar_f32(&hw, 2.)];
+        let lhs = Array::scalar_f32(&hw, 1.);
+        let rhs = Array::scalar_f32(&hw, 2.);
         let expected = Array::scalar_f32(&hw, 3.);
-        let observed = op.perform(&inputs.iter().collect::<Vec<_>>()).unwrap();
+        let observed = op.perform(&[&lhs, &rhs]).unwrap();
         assert_eq!(observed.shape(), expected.shape());
         assert_eq!(observed.get_scalar_f32(), expected.get_scalar_f32());
     }

--- a/src/operator/add.rs
+++ b/src/operator/add.rs
@@ -1,8 +1,4 @@
-use crate::array::Array;
-use crate::node::Node;
-use crate::operator::Operator;
-use crate::result::Result;
-use crate::shape::Shape;
+use crate::operator::*;
 
 pub(crate) struct Add;
 
@@ -44,11 +40,8 @@ impl<'hw> Operator<'hw> for Add {
 
 #[cfg(test)]
 mod tests {
-    use crate::array::Array;
     use crate::hardware::cpu::CpuHardware;
-    use crate::operator::add::Add;
-    use crate::operator::Operator;
-    use std::cell::RefCell;
+    use crate::operator::add::*;
 
     #[test]
     fn test_add_op() {

--- a/src/operator/add.rs
+++ b/src/operator/add.rs
@@ -41,6 +41,7 @@ impl<'hw> Operator<'hw> for Add {
 #[cfg(test)]
 mod tests {
     use crate::hardware::cpu::CpuHardware;
+    use crate::make_shape;
     use crate::operator::add::*;
 
     #[test]
@@ -48,6 +49,38 @@ mod tests {
         let op = Add::new();
         assert_eq!(op.name(), "Add");
         assert_eq!(op.input_size(), 2);
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_perform_shape() {
+        let op = Add::new();
+        assert_eq!(op.perform_shape(&[&make_shape![], &make_shape![]]), Ok(make_shape![]));
+        assert_eq!(op.perform_shape(&[&make_shape![0], &make_shape![0]]), Ok(make_shape![0]));
+        assert_eq!(op.perform_shape(&[&make_shape![3], &make_shape![3]]), Ok(make_shape![3]));
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_perform_shape_invalid() {
+        let op = Add::new();
+        assert!(op.perform_shape(&[&make_shape![], &make_shape![0]]).is_err());
+        assert!(op.perform_shape(&[&make_shape![], &make_shape![3]]).is_err());
+        assert!(op.perform_shape(&[&make_shape![0], &make_shape![]]).is_err());
+        assert!(op.perform_shape(&[&make_shape![0], &make_shape![3]]).is_err());
+        assert!(op.perform_shape(&[&make_shape![3], &make_shape![]]).is_err());
+        assert!(op.perform_shape(&[&make_shape![3], &make_shape![0]]).is_err());
+    }
+
+    #[test]
+    fn test_perform_hardware() {
+        let hw1 = RefCell::new(CpuHardware::new());
+        let hw2 = RefCell::new(CpuHardware::new());
+        let op = Add::new();
+
+        assert!(ptr::eq(op.perform_hardware(&[&hw1, &hw1]).unwrap(), &hw1));
+        assert!(ptr::eq(op.perform_hardware(&[&hw2, &hw2]).unwrap(), &hw2));
+        assert!(op.perform_hardware(&[&hw1, &hw2]).is_err());
     }
 
     #[test]

--- a/src/operator/add.rs
+++ b/src/operator/add.rs
@@ -44,11 +44,16 @@ mod tests {
     use crate::operator::add::*;
 
     #[test]
-    fn test_add_op() {
-        let hw = RefCell::new(CpuHardware::new());
+    fn test_properties() {
         let op = Add::new();
         assert_eq!(op.name(), "Add");
         assert_eq!(op.input_size(), 2);
+    }
+
+    #[test]
+    fn test_perform() {
+        let hw = RefCell::new(CpuHardware::new());
+        let op = Add::new();
         let inputs = vec![Array::scalar_f32(&hw, 1.), Array::scalar_f32(&hw, 2.)];
         let expected = Array::scalar_f32(&hw, 3.);
         let observed = op.perform(&inputs.iter().collect::<Vec<_>>()).unwrap();

--- a/src/operator/constant.rs
+++ b/src/operator/constant.rs
@@ -52,9 +52,8 @@ mod tests {
     fn test_perform() {
         let hw = RefCell::new(CpuHardware::new());
         let op = Constant::new(Array::scalar_f32(&hw, 123.));
-        let input_refs = vec![];
         let expected = Array::scalar_f32(&hw, 123.);
-        let observed = op.perform(&input_refs).unwrap();
+        let observed = op.perform(&[]).unwrap();
         assert_eq!(observed.shape(), expected.shape());
         assert_eq!(observed.get_scalar_f32(), expected.get_scalar_f32());
     }

--- a/src/operator/constant.rs
+++ b/src/operator/constant.rs
@@ -1,7 +1,4 @@
-use crate::array::Array;
-use crate::operator::Operator;
-use crate::result::Result;
-use crate::shape::Shape;
+use crate::operator::*;
 
 pub(crate) struct Constant<'hw> {
     value: Array<'hw>,
@@ -24,6 +21,13 @@ impl<'hw> Operator<'hw> for Constant<'hw> {
 
     fn perform_shape(&self, _inputs: &[&Shape]) -> Result<Shape> {
         Ok(self.value.shape().clone())
+    }
+
+    fn perform_hardware(
+        &self,
+        _inputs: &[&'hw RefCell<dyn Hardware>],
+    ) -> Result<&'hw RefCell<dyn Hardware>> {
+        Ok(self.value.hardware())
     }
 
     fn perform(&self, _inputs: &[&Array<'hw>]) -> Result<Array<'hw>> {

--- a/src/operator/constant.rs
+++ b/src/operator/constant.rs
@@ -41,11 +41,17 @@ mod tests {
     use crate::operator::constant::*;
 
     #[test]
-    fn test_constant_op() {
+    fn test_properties() {
         let hw = RefCell::new(CpuHardware::new());
         let op = Constant::new(Array::scalar_f32(&hw, 123.));
         assert_eq!(op.name(), "Constant");
         assert_eq!(op.input_size(), 0);
+    }
+
+    #[test]
+    fn test_perform() {
+        let hw = RefCell::new(CpuHardware::new());
+        let op = Constant::new(Array::scalar_f32(&hw, 123.));
         let input_refs = vec![];
         let expected = Array::scalar_f32(&hw, 123.);
         let observed = op.perform(&input_refs).unwrap();

--- a/src/operator/constant.rs
+++ b/src/operator/constant.rs
@@ -38,6 +38,7 @@ impl<'hw> Operator<'hw> for Constant<'hw> {
 #[cfg(test)]
 mod tests {
     use crate::hardware::cpu::CpuHardware;
+    use crate::make_shape;
     use crate::operator::constant::*;
 
     #[test]
@@ -46,6 +47,34 @@ mod tests {
         let op = Constant::new(Array::scalar_f32(&hw, 123.));
         assert_eq!(op.name(), "Constant");
         assert_eq!(op.input_size(), 0);
+    }
+
+    #[test]
+    fn test_perform_shape_scalar() {
+        let hw = RefCell::new(CpuHardware::new());
+        let op = Constant::new(Array::scalar_f32(&hw, 123.));
+        assert_eq!(op.perform_shape(&[]), Ok(make_shape![]));
+    }
+
+    #[test]
+    fn test_perform_shape_0() {
+        let hw = RefCell::new(CpuHardware::new());
+        let op = Constant::new(Array::fill_f32(&hw, make_shape![0], 123.));
+        assert_eq!(op.perform_shape(&[]), Ok(make_shape![0]));
+    }
+
+    #[test]
+    fn test_perform_shape_n() {
+        let hw = RefCell::new(CpuHardware::new());
+        let op = Constant::new(Array::fill_f32(&hw, make_shape![3], 123.));
+        assert_eq!(op.perform_shape(&[]), Ok(make_shape![3]));
+    }
+
+    #[test]
+    fn test_perform_hardware() {
+        let hw = RefCell::new(CpuHardware::new());
+        let op = Constant::new(Array::scalar_f32(&hw, 123.));
+        assert!(ptr::eq(op.perform_hardware(&[]).unwrap(), &hw));
     }
 
     #[test]

--- a/src/operator/constant.rs
+++ b/src/operator/constant.rs
@@ -37,11 +37,8 @@ impl<'hw> Operator<'hw> for Constant<'hw> {
 
 #[cfg(test)]
 mod tests {
-    use crate::array::Array;
     use crate::hardware::cpu::CpuHardware;
-    use crate::operator::constant::Constant;
-    use crate::operator::Operator;
-    use std::cell::RefCell;
+    use crate::operator::constant::*;
 
     #[test]
     fn test_constant_op() {

--- a/src/operator/div.rs
+++ b/src/operator/div.rs
@@ -42,6 +42,7 @@ impl<'hw> Operator<'hw> for Div {
 #[cfg(test)]
 mod tests {
     use crate::hardware::cpu::CpuHardware;
+    use crate::make_shape;
     use crate::operator::div::*;
 
     #[test]
@@ -49,6 +50,38 @@ mod tests {
         let op = Div::new();
         assert_eq!(op.name(), "Div");
         assert_eq!(op.input_size(), 2);
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_perform_shape() {
+        let op = Div::new();
+        assert_eq!(op.perform_shape(&[&make_shape![], &make_shape![]]), Ok(make_shape![]));
+        assert_eq!(op.perform_shape(&[&make_shape![0], &make_shape![0]]), Ok(make_shape![0]));
+        assert_eq!(op.perform_shape(&[&make_shape![3], &make_shape![3]]), Ok(make_shape![3]));
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_perform_shape_invalid() {
+        let op = Div::new();
+        assert!(op.perform_shape(&[&make_shape![], &make_shape![0]]).is_err());
+        assert!(op.perform_shape(&[&make_shape![], &make_shape![3]]).is_err());
+        assert!(op.perform_shape(&[&make_shape![0], &make_shape![]]).is_err());
+        assert!(op.perform_shape(&[&make_shape![0], &make_shape![3]]).is_err());
+        assert!(op.perform_shape(&[&make_shape![3], &make_shape![]]).is_err());
+        assert!(op.perform_shape(&[&make_shape![3], &make_shape![0]]).is_err());
+    }
+
+    #[test]
+    fn test_perform_hardware() {
+        let hw1 = RefCell::new(CpuHardware::new());
+        let hw2 = RefCell::new(CpuHardware::new());
+        let op = Div::new();
+
+        assert!(ptr::eq(op.perform_hardware(&[&hw1, &hw1]).unwrap(), &hw1));
+        assert!(ptr::eq(op.perform_hardware(&[&hw2, &hw2]).unwrap(), &hw2));
+        assert!(op.perform_hardware(&[&hw1, &hw2]).is_err());
     }
 
     #[test]

--- a/src/operator/div.rs
+++ b/src/operator/div.rs
@@ -1,8 +1,4 @@
-use crate::array::Array;
-use crate::node::Node;
-use crate::operator::Operator;
-use crate::result::Result;
-use crate::shape::Shape;
+use crate::operator::*;
 
 pub(crate) struct Div;
 
@@ -45,11 +41,8 @@ impl<'hw> Operator<'hw> for Div {
 
 #[cfg(test)]
 mod tests {
-    use crate::array::Array;
     use crate::hardware::cpu::CpuHardware;
-    use crate::operator::div::Div;
-    use crate::operator::Operator;
-    use std::cell::RefCell;
+    use crate::operator::div::*;
 
     #[test]
     fn test_div_op() {

--- a/src/operator/div.rs
+++ b/src/operator/div.rs
@@ -45,11 +45,16 @@ mod tests {
     use crate::operator::div::*;
 
     #[test]
-    fn test_div_op() {
-        let hw = RefCell::new(CpuHardware::new());
+    fn test_properties() {
         let op = Div::new();
         assert_eq!(op.name(), "Div");
         assert_eq!(op.input_size(), 2);
+    }
+
+    #[test]
+    fn test_perform() {
+        let hw = RefCell::new(CpuHardware::new());
+        let op = Div::new();
         let inputs = vec![Array::scalar_f32(&hw, 1.), Array::scalar_f32(&hw, 2.)];
         let expected = Array::scalar_f32(&hw, 0.5);
         let observed = op.perform(&inputs.iter().collect::<Vec<_>>()).unwrap();

--- a/src/operator/div.rs
+++ b/src/operator/div.rs
@@ -55,9 +55,10 @@ mod tests {
     fn test_perform() {
         let hw = RefCell::new(CpuHardware::new());
         let op = Div::new();
-        let inputs = vec![Array::scalar_f32(&hw, 1.), Array::scalar_f32(&hw, 2.)];
+        let lhs = Array::scalar_f32(&hw, 1.);
+        let rhs = Array::scalar_f32(&hw, 2.);
         let expected = Array::scalar_f32(&hw, 0.5);
-        let observed = op.perform(&inputs.iter().collect::<Vec<_>>()).unwrap();
+        let observed = op.perform(&[&lhs, &rhs]).unwrap();
         assert_eq!(observed.shape(), expected.shape());
         assert_eq!(observed.get_scalar_f32(), expected.get_scalar_f32());
     }

--- a/src/operator/fill.rs
+++ b/src/operator/fill.rs
@@ -1,9 +1,4 @@
-use crate::array::Array;
-use crate::hardware::Hardware;
-use crate::operator::Operator;
-use crate::result::Result;
-use crate::shape::Shape;
-use std::cell::RefCell;
+use crate::operator::*;
 
 /// Fill operator: creates an array with specific hardware/shape, filled by a single value.
 pub(crate) struct Fill<'hw> {
@@ -58,12 +53,9 @@ impl<'hw> Operator<'hw> for Fill<'hw> {
 
 #[cfg(test)]
 mod tests {
-    use crate::array::Array;
     use crate::hardware::cpu::CpuHardware;
     use crate::make_shape;
-    use crate::operator::fill::Fill;
-    use crate::operator::Operator;
-    use std::cell::RefCell;
+    use crate::operator::fill::*;
 
     #[test]
     fn test_op_scalar() {

--- a/src/operator/fill.rs
+++ b/src/operator/fill.rs
@@ -69,9 +69,8 @@ mod tests {
     fn test_perform_scalar() {
         let hw = RefCell::new(CpuHardware::new());
         let op = Fill::new(&hw, make_shape![], 123.);
-        let input_refs = [];
         let expected = Array::fill_f32(&hw, make_shape![], 123.);
-        let observed = op.perform(&input_refs).unwrap();
+        let observed = op.perform(&[]).unwrap();
         assert_eq!(observed.shape(), expected.shape());
         assert_eq!(observed.get_scalar_f32(), expected.get_scalar_f32());
     }
@@ -80,9 +79,8 @@ mod tests {
     fn test_perform_0() {
         let hw = RefCell::new(CpuHardware::new());
         let op = Fill::new(&hw, make_shape![0], 123.);
-        let input_refs = [];
         let expected = Array::fill_f32(&hw, make_shape![0], 123.);
-        let observed = op.perform(&input_refs).unwrap();
+        let observed = op.perform(&[]).unwrap();
         assert_eq!(observed.shape(), expected.shape());
         assert_eq!(observed.get_values_f32(), expected.get_values_f32());
     }
@@ -91,9 +89,8 @@ mod tests {
     fn test_perform_n() {
         let hw = RefCell::new(CpuHardware::new());
         let op = Fill::new(&hw, make_shape![3], 123.);
-        let input_refs = [];
         let expected = Array::fill_f32(&hw, make_shape![3], 123.);
-        let observed = op.perform(&input_refs).unwrap();
+        let observed = op.perform(&[]).unwrap();
         assert_eq!(observed.shape(), expected.shape());
         assert_eq!(observed.get_values_f32(), expected.get_values_f32());
     }

--- a/src/operator/fill.rs
+++ b/src/operator/fill.rs
@@ -66,6 +66,34 @@ mod tests {
     }
 
     #[test]
+    fn test_perform_shape_scalar() {
+        let hw = RefCell::new(CpuHardware::new());
+        let op = Fill::new(&hw, make_shape![], 123.);
+        assert_eq!(op.perform_shape(&[]), Ok(make_shape![]));
+    }
+
+    #[test]
+    fn test_perform_shape_0() {
+        let hw = RefCell::new(CpuHardware::new());
+        let op = Fill::new(&hw, make_shape![0], 123.);
+        assert_eq!(op.perform_shape(&[]), Ok(make_shape![0]));
+    }
+
+    #[test]
+    fn test_perform_shape_n() {
+        let hw = RefCell::new(CpuHardware::new());
+        let op = Fill::new(&hw, make_shape![3], 123.);
+        assert_eq!(op.perform_shape(&[]), Ok(make_shape![3]));
+    }
+
+    #[test]
+    fn test_perform_hardware() {
+        let hw = RefCell::new(CpuHardware::new());
+        let op = Fill::new(&hw, make_shape![], 123.);
+        assert!(ptr::eq(op.perform_hardware(&[]).unwrap(), &hw));
+    }
+
+    #[test]
     fn test_perform_scalar() {
         let hw = RefCell::new(CpuHardware::new());
         let op = Fill::new(&hw, make_shape![], 123.);

--- a/src/operator/fill.rs
+++ b/src/operator/fill.rs
@@ -58,11 +58,17 @@ mod tests {
     use crate::operator::fill::*;
 
     #[test]
-    fn test_op_scalar() {
+    fn test_properties() {
         let hw = RefCell::new(CpuHardware::new());
         let op = Fill::new(&hw, make_shape![], 123.);
         assert_eq!(op.name(), "Fill");
         assert_eq!(op.input_size(), 0);
+    }
+
+    #[test]
+    fn test_perform_scalar() {
+        let hw = RefCell::new(CpuHardware::new());
+        let op = Fill::new(&hw, make_shape![], 123.);
         let input_refs = [];
         let expected = Array::fill_f32(&hw, make_shape![], 123.);
         let observed = op.perform(&input_refs).unwrap();
@@ -71,11 +77,9 @@ mod tests {
     }
 
     #[test]
-    fn test_op_0() {
+    fn test_perform_0() {
         let hw = RefCell::new(CpuHardware::new());
         let op = Fill::new(&hw, make_shape![0], 123.);
-        assert_eq!(op.name(), "Fill");
-        assert_eq!(op.input_size(), 0);
         let input_refs = [];
         let expected = Array::fill_f32(&hw, make_shape![0], 123.);
         let observed = op.perform(&input_refs).unwrap();
@@ -84,11 +88,9 @@ mod tests {
     }
 
     #[test]
-    fn test_op_n() {
+    fn test_perform_n() {
         let hw = RefCell::new(CpuHardware::new());
         let op = Fill::new(&hw, make_shape![3], 123.);
-        assert_eq!(op.name(), "Fill");
-        assert_eq!(op.input_size(), 0);
         let input_refs = [];
         let expected = Array::fill_f32(&hw, make_shape![3], 123.);
         let observed = op.perform(&input_refs).unwrap();

--- a/src/operator/fill.rs
+++ b/src/operator/fill.rs
@@ -40,6 +40,13 @@ impl<'hw> Operator<'hw> for Fill<'hw> {
         Ok(self.shape.clone())
     }
 
+    fn perform_hardware(
+        &self,
+        _inputs: &[&'hw RefCell<dyn Hardware>],
+    ) -> Result<&'hw RefCell<dyn Hardware>> {
+        Ok(self.hardware)
+    }
+
     fn perform(&self, _inputs: &[&Array<'hw>]) -> Result<Array<'hw>> {
         Ok(Array::fill_f32(
             self.hardware,

--- a/src/operator/mul.rs
+++ b/src/operator/mul.rs
@@ -1,8 +1,4 @@
-use crate::array::Array;
-use crate::node::Node;
-use crate::operator::Operator;
-use crate::result::Result;
-use crate::shape::Shape;
+use crate::operator::*;
 
 pub(crate) struct Mul;
 
@@ -44,11 +40,8 @@ impl<'hw> Operator<'hw> for Mul {
 
 #[cfg(test)]
 mod tests {
-    use crate::array::Array;
     use crate::hardware::cpu::CpuHardware;
-    use crate::operator::mul::Mul;
-    use crate::operator::Operator;
-    use std::cell::RefCell;
+    use crate::operator::mul::*;
 
     #[test]
     fn test_mul_op() {

--- a/src/operator/mul.rs
+++ b/src/operator/mul.rs
@@ -44,11 +44,16 @@ mod tests {
     use crate::operator::mul::*;
 
     #[test]
-    fn test_mul_op() {
-        let hw = RefCell::new(CpuHardware::new());
+    fn test_properties() {
         let op = Mul::new();
         assert_eq!(op.name(), "Mul");
         assert_eq!(op.input_size(), 2);
+    }
+
+    #[test]
+    fn test_perform() {
+        let hw = RefCell::new(CpuHardware::new());
+        let op = Mul::new();
         let inputs = vec![Array::scalar_f32(&hw, 1.), Array::scalar_f32(&hw, 2.)];
         let expected = Array::scalar_f32(&hw, 2.);
         let observed = op.perform(&inputs.iter().collect::<Vec<_>>()).unwrap();

--- a/src/operator/mul.rs
+++ b/src/operator/mul.rs
@@ -54,9 +54,10 @@ mod tests {
     fn test_perform() {
         let hw = RefCell::new(CpuHardware::new());
         let op = Mul::new();
-        let inputs = vec![Array::scalar_f32(&hw, 1.), Array::scalar_f32(&hw, 2.)];
+        let lhs = Array::scalar_f32(&hw, 1.);
+        let rhs = Array::scalar_f32(&hw, 2.);
         let expected = Array::scalar_f32(&hw, 2.);
-        let observed = op.perform(&inputs.iter().collect::<Vec<_>>()).unwrap();
+        let observed = op.perform(&[&lhs, &rhs]).unwrap();
         assert_eq!(observed.shape(), expected.shape());
         assert_eq!(observed.get_scalar_f32(), expected.get_scalar_f32());
     }

--- a/src/operator/mul.rs
+++ b/src/operator/mul.rs
@@ -41,6 +41,7 @@ impl<'hw> Operator<'hw> for Mul {
 #[cfg(test)]
 mod tests {
     use crate::hardware::cpu::CpuHardware;
+    use crate::make_shape;
     use crate::operator::mul::*;
 
     #[test]
@@ -48,6 +49,38 @@ mod tests {
         let op = Mul::new();
         assert_eq!(op.name(), "Mul");
         assert_eq!(op.input_size(), 2);
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_perform_shape() {
+        let op = Mul::new();
+        assert_eq!(op.perform_shape(&[&make_shape![], &make_shape![]]), Ok(make_shape![]));
+        assert_eq!(op.perform_shape(&[&make_shape![0], &make_shape![0]]), Ok(make_shape![0]));
+        assert_eq!(op.perform_shape(&[&make_shape![3], &make_shape![3]]), Ok(make_shape![3]));
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_perform_shape_invalid() {
+        let op = Mul::new();
+        assert!(op.perform_shape(&[&make_shape![], &make_shape![0]]).is_err());
+        assert!(op.perform_shape(&[&make_shape![], &make_shape![3]]).is_err());
+        assert!(op.perform_shape(&[&make_shape![0], &make_shape![]]).is_err());
+        assert!(op.perform_shape(&[&make_shape![0], &make_shape![3]]).is_err());
+        assert!(op.perform_shape(&[&make_shape![3], &make_shape![]]).is_err());
+        assert!(op.perform_shape(&[&make_shape![3], &make_shape![0]]).is_err());
+    }
+
+    #[test]
+    fn test_perform_hardware() {
+        let hw1 = RefCell::new(CpuHardware::new());
+        let hw2 = RefCell::new(CpuHardware::new());
+        let op = Mul::new();
+
+        assert!(ptr::eq(op.perform_hardware(&[&hw1, &hw1]).unwrap(), &hw1));
+        assert!(ptr::eq(op.perform_hardware(&[&hw2, &hw2]).unwrap(), &hw2));
+        assert!(op.perform_hardware(&[&hw1, &hw2]).is_err());
     }
 
     #[test]

--- a/src/operator/neg.rs
+++ b/src/operator/neg.rs
@@ -54,9 +54,9 @@ mod tests {
     fn test_perform() {
         let hw = RefCell::new(CpuHardware::new());
         let op = Neg::new();
-        let inputs = vec![Array::scalar_f32(&hw, 42.)];
+        let input = Array::scalar_f32(&hw, 42.);
         let expected = Array::scalar_f32(&hw, -42.);
-        let observed = op.perform(&inputs.iter().collect::<Vec<_>>()).unwrap();
+        let observed = op.perform(&[&input]).unwrap();
         assert_eq!(observed.shape(), expected.shape());
         assert_eq!(observed.get_scalar_f32(), expected.get_scalar_f32());
     }

--- a/src/operator/neg.rs
+++ b/src/operator/neg.rs
@@ -41,6 +41,7 @@ impl<'hw> Operator<'hw> for Neg {
 #[cfg(test)]
 mod tests {
     use crate::hardware::cpu::CpuHardware;
+    use crate::make_shape;
     use crate::operator::neg::*;
 
     #[test]
@@ -48,6 +49,24 @@ mod tests {
         let op = Neg::new();
         assert_eq!(op.name(), "Neg");
         assert_eq!(op.input_size(), 1);
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_perform_shape() {
+        let op = Neg::new();
+        
+        assert_eq!(op.perform_shape(&[&make_shape![]]), Ok(make_shape![]));
+        assert_eq!(op.perform_shape(&[&make_shape![0]]), Ok(make_shape![0]));
+        assert_eq!(op.perform_shape(&[&make_shape![3]]), Ok(make_shape![3]));
+    }
+
+    #[test]
+    fn test_perform_hardware() {
+        let hw = RefCell::new(CpuHardware::new());
+        let op = Neg::new();
+
+        assert!(ptr::eq(op.perform_hardware(&[&hw]).unwrap(), &hw));
     }
 
     #[test]

--- a/src/operator/neg.rs
+++ b/src/operator/neg.rs
@@ -44,11 +44,16 @@ mod tests {
     use crate::operator::neg::*;
 
     #[test]
-    fn test_neg_op() {
-        let hw = RefCell::new(CpuHardware::new());
+    fn test_properties() {
         let op = Neg::new();
         assert_eq!(op.name(), "Neg");
         assert_eq!(op.input_size(), 1);
+    }
+
+    #[test]
+    fn test_perform() {
+        let hw = RefCell::new(CpuHardware::new());
+        let op = Neg::new();
         let inputs = vec![Array::scalar_f32(&hw, 42.)];
         let expected = Array::scalar_f32(&hw, -42.);
         let observed = op.perform(&inputs.iter().collect::<Vec<_>>()).unwrap();

--- a/src/operator/neg.rs
+++ b/src/operator/neg.rs
@@ -1,8 +1,4 @@
-use crate::array::Array;
-use crate::node::Node;
-use crate::operator::Operator;
-use crate::result::Result;
-use crate::shape::Shape;
+use crate::operator::*;
 
 pub(crate) struct Neg;
 
@@ -44,11 +40,8 @@ impl<'hw> Operator<'hw> for Neg {
 
 #[cfg(test)]
 mod tests {
-    use crate::array::Array;
     use crate::hardware::cpu::CpuHardware;
-    use crate::operator::neg::Neg;
-    use crate::operator::Operator;
-    use std::cell::RefCell;
+    use crate::operator::neg::*;
 
     #[test]
     fn test_neg_op() {

--- a/src/operator/sub.rs
+++ b/src/operator/sub.rs
@@ -54,9 +54,10 @@ mod tests {
     fn test_perform() {
         let hw = RefCell::new(CpuHardware::new());
         let op = Sub::new();
-        let inputs = vec![Array::scalar_f32(&hw, 1.), Array::scalar_f32(&hw, 2.)];
+        let lhs = Array::scalar_f32(&hw, 1.);
+        let rhs = Array::scalar_f32(&hw, 2.);
         let expected = Array::scalar_f32(&hw, -1.);
-        let observed = op.perform(&inputs.iter().collect::<Vec<_>>()).unwrap();
+        let observed = op.perform(&[&lhs, &rhs]).unwrap();
         assert_eq!(observed.shape(), expected.shape());
         assert_eq!(observed.get_scalar_f32(), expected.get_scalar_f32());
     }

--- a/src/operator/sub.rs
+++ b/src/operator/sub.rs
@@ -1,8 +1,4 @@
-use crate::array::Array;
-use crate::node::Node;
-use crate::operator::Operator;
-use crate::result::Result;
-use crate::shape::Shape;
+use crate::operator::*;
 
 pub(crate) struct Sub;
 
@@ -44,11 +40,8 @@ impl<'hw> Operator<'hw> for Sub {
 
 #[cfg(test)]
 mod tests {
-    use crate::array::Array;
     use crate::hardware::cpu::CpuHardware;
-    use crate::operator::sub::Sub;
-    use crate::operator::Operator;
-    use std::cell::RefCell;
+    use crate::operator::sub::*;
 
     #[test]
     fn test_sub_op() {

--- a/src/operator/sub.rs
+++ b/src/operator/sub.rs
@@ -41,6 +41,7 @@ impl<'hw> Operator<'hw> for Sub {
 #[cfg(test)]
 mod tests {
     use crate::hardware::cpu::CpuHardware;
+    use crate::make_shape;
     use crate::operator::sub::*;
 
     #[test]
@@ -48,6 +49,38 @@ mod tests {
         let op = Sub::new();
         assert_eq!(op.name(), "Sub");
         assert_eq!(op.input_size(), 2);
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_perform_shape() {
+        let op = Sub::new();
+        assert_eq!(op.perform_shape(&[&make_shape![], &make_shape![]]), Ok(make_shape![]));
+        assert_eq!(op.perform_shape(&[&make_shape![0], &make_shape![0]]), Ok(make_shape![0]));
+        assert_eq!(op.perform_shape(&[&make_shape![3], &make_shape![3]]), Ok(make_shape![3]));
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_perform_shape_invalid() {
+        let op = Sub::new();
+        assert!(op.perform_shape(&[&make_shape![], &make_shape![0]]).is_err());
+        assert!(op.perform_shape(&[&make_shape![], &make_shape![3]]).is_err());
+        assert!(op.perform_shape(&[&make_shape![0], &make_shape![]]).is_err());
+        assert!(op.perform_shape(&[&make_shape![0], &make_shape![3]]).is_err());
+        assert!(op.perform_shape(&[&make_shape![3], &make_shape![]]).is_err());
+        assert!(op.perform_shape(&[&make_shape![3], &make_shape![0]]).is_err());
+    }
+
+    #[test]
+    fn test_perform_hardware() {
+        let hw1 = RefCell::new(CpuHardware::new());
+        let hw2 = RefCell::new(CpuHardware::new());
+        let op = Sub::new();
+
+        assert!(ptr::eq(op.perform_hardware(&[&hw1, &hw1]).unwrap(), &hw1));
+        assert!(ptr::eq(op.perform_hardware(&[&hw2, &hw2]).unwrap(), &hw2));
+        assert!(op.perform_hardware(&[&hw1, &hw2]).is_err());
     }
 
     #[test]

--- a/src/operator/sub.rs
+++ b/src/operator/sub.rs
@@ -44,11 +44,16 @@ mod tests {
     use crate::operator::sub::*;
 
     #[test]
-    fn test_sub_op() {
-        let hw = RefCell::new(CpuHardware::new());
+    fn test_properties() {
         let op = Sub::new();
         assert_eq!(op.name(), "Sub");
         assert_eq!(op.input_size(), 2);
+    }
+
+    #[test]
+    fn test_perform() {
+        let hw = RefCell::new(CpuHardware::new());
+        let op = Sub::new();
         let inputs = vec![Array::scalar_f32(&hw, 1.), Array::scalar_f32(&hw, 2.)];
         let expected = Array::scalar_f32(&hw, -1.);
         let observed = op.perform(&inputs.iter().collect::<Vec<_>>()).unwrap();


### PR DESCRIPTION
This change contains:
- Simplify import statements with wildcards for some descendant files.
- Separates some tests for Operators.
- Add tests for `Operator::perform_shape` and `Operator::perform_hardware`.
- Adds documentation of `Operator`.

Blocking change: #14