### PR TITLE
swap arguments graph and hardware.

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -25,8 +25,8 @@ impl<'hw: 'op, 'op: 'g, 'g> Node<'hw, 'op, 'g> {
     }
 
     pub fn from_scalar(
-        hardware: &'hw RefCell<dyn Hardware>,
         graph: &'g RefCell<Graph<'hw, 'op>>,
+        hardware: &'hw RefCell<dyn Hardware>,
         value: f32,
     ) -> Self {
         Self::new(
@@ -91,13 +91,13 @@ impl<'hw: 'op, 'op: 'g, 'g> Node<'hw, 'op, 'g> {
     ///
     /// # Arguments
     ///
-    /// * `hardware` - `Hardware` object to hold the value.
     /// * `graph` - `Graph` object to register the operation.
+    /// * `hardware` - `Hardware` object to hold the value.
     /// * `shape` - `Shape` of the output array.
     /// * `value` - Value of each element in the output array.
     pub fn fill(
-        hardware: &'hw RefCell<dyn Hardware>,
         graph: &'g RefCell<Graph<'hw, 'op>>,
+        hardware: &'hw RefCell<dyn Hardware>,
         shape: Shape,
         value: f32,
     ) -> Self {
@@ -273,7 +273,7 @@ pub fn grad<'hw, 'op, 'g>(
 
     // Assigns the gradient of `y` == 1.
     *(unsafe { gradients.get_unchecked_mut(last_step_id) }) =
-        Some(Node::fill(y.hardware(), g, y.shape(), 1.));
+        Some(Node::fill(g, y.hardware(), y.shape(), 1.));
 
     // Performs backpropagation.
     for step_id in ((first_step_id + 1)..=last_step_id).rev() {
@@ -318,7 +318,7 @@ pub fn grad<'hw, 'op, 'g>(
                 Some(grad_node) => *grad_node,
                 // No gradient propagation occurred for this node,
                 // assuming that the gradient is 0.
-                None => Node::fill(node.hardware(), g, node.shape(), 0.),
+                None => Node::fill(g, node.hardware(), node.shape(), 0.),
             }
         })
         .collect::<Vec<_>>()

--- a/src/node/grad_tests.rs
+++ b/src/node/grad_tests.rs
@@ -6,7 +6,7 @@ fn test_empty() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let x = Node::from_scalar(&hw, &g, 42.);
+    let x = Node::from_scalar(&g, &hw, 42.);
 
     let gx = grad(x, &[]);
     assert!(gx.is_empty());
@@ -17,7 +17,7 @@ fn test_self() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let x = Node::from_scalar(&hw, &g, 42.);
+    let x = Node::from_scalar(&g, &hw, 42.);
 
     let gx = grad(x, &[x]);
     assert_eq!(gx.len(), 1);
@@ -34,8 +34,8 @@ fn test_unrelated() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let x = Node::from_scalar(&hw, &g, 42.);
-    let y = Node::from_scalar(&hw, &g, 42.);
+    let x = Node::from_scalar(&g, &hw, 42.);
+    let y = Node::from_scalar(&g, &hw, 42.);
 
     let gx = grad(y, &[x]);
     assert_eq!(gx.len(), 1);
@@ -52,7 +52,7 @@ fn test_neg() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let x = Node::from_scalar(&hw, &g, 42.);
+    let x = Node::from_scalar(&g, &hw, 42.);
     let y = -x;
 
     let gx = grad(y, &[x]);
@@ -70,8 +70,8 @@ fn test_add() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let a = Node::from_scalar(&hw, &g, 123.);
-    let b = Node::from_scalar(&hw, &g, 456.);
+    let a = Node::from_scalar(&g, &hw, 123.);
+    let b = Node::from_scalar(&g, &hw, 456.);
     let y = a + b;
 
     let gx = grad(y, &[a, b]);
@@ -93,8 +93,8 @@ fn test_sub() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let a = Node::from_scalar(&hw, &g, 123.);
-    let b = Node::from_scalar(&hw, &g, 456.);
+    let a = Node::from_scalar(&g, &hw, 123.);
+    let b = Node::from_scalar(&g, &hw, 456.);
     let y = a - b;
 
     let gx = grad(y, &[a, b]);
@@ -116,8 +116,8 @@ fn test_mul() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let a = Node::from_scalar(&hw, &g, 123.);
-    let b = Node::from_scalar(&hw, &g, 456.);
+    let a = Node::from_scalar(&g, &hw, 123.);
+    let b = Node::from_scalar(&g, &hw, 456.);
     let y = a * b;
 
     let gx = grad(y, &[a, b]);
@@ -139,7 +139,7 @@ fn test_mul_quadratic() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let x = Node::from_scalar(&hw, &g, 123.);
+    let x = Node::from_scalar(&g, &hw, 123.);
     // This calculation generates a diamond dependency between x and y
     // so that gradient summation x + x is happened during backpropagation.
     let y = x * x;
@@ -159,8 +159,8 @@ fn test_div() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let a = Node::from_scalar(&hw, &g, 3.);
-    let b = Node::from_scalar(&hw, &g, 2.);
+    let a = Node::from_scalar(&g, &hw, 3.);
+    let b = Node::from_scalar(&g, &hw, 2.);
     let y = a / b;
 
     let gx = grad(y, &[a, b]);
@@ -182,9 +182,9 @@ fn test_multiple_computation() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let a = Node::from_scalar(&hw, &g, 1.);
-    let b = Node::from_scalar(&hw, &g, 2.);
-    let c = Node::from_scalar(&hw, &g, 3.);
+    let a = Node::from_scalar(&g, &hw, 1.);
+    let b = Node::from_scalar(&g, &hw, 2.);
+    let c = Node::from_scalar(&g, &hw, 3.);
     let y = a + -b * c;
 
     let gx = grad(y, &[a, b, c]);
@@ -210,7 +210,7 @@ fn test_higher_order_gradients() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let x = Node::from_scalar(&hw, &g, 5.);
+    let x = Node::from_scalar(&g, &hw, 5.);
     let y = x * x * x;
 
     let gx1 = grad(y, &[x])[0];
@@ -242,8 +242,8 @@ fn test_gradient_of_multiple_variables() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let a = Node::from_scalar(&hw, &g, 2.);
-    let b = Node::from_scalar(&hw, &g, 3.);
+    let a = Node::from_scalar(&g, &hw, 2.);
+    let b = Node::from_scalar(&g, &hw, 3.);
     let y = a * a * b;
 
     let y_a = grad(y, &[a])[0];
@@ -288,7 +288,7 @@ fn test_different_graph() {
     let g1 = RefCell::new(Graph::new());
     let g2 = RefCell::new(Graph::new());
 
-    let x = Node::from_scalar(&hw, &g1, 2.);
-    let y = Node::from_scalar(&hw, &g2, 3.);
+    let x = Node::from_scalar(&g1, &hw, 2.);
+    let y = Node::from_scalar(&g2, &hw, 3.);
     let _gx = grad(y, &[x])[0];
 }

--- a/src/node/tests.rs
+++ b/src/node/tests.rs
@@ -5,8 +5,8 @@ use crate::node::*;
 fn test_steps() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
-    let lhs = Node::from_scalar(&hw, &g, 1.);
-    let rhs = Node::from_scalar(&hw, &g, 2.);
+    let lhs = Node::from_scalar(&g, &hw, 1.);
+    let rhs = Node::from_scalar(&g, &hw, 2.);
     let ret = lhs + rhs;
 
     assert_eq!(lhs, Node::new(&g, 0));
@@ -37,7 +37,7 @@ fn test_neg() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let src = Node::from_scalar(&hw, &g, 42.);
+    let src = Node::from_scalar(&g, &hw, 42.);
     let dest = -src;
 
     assert_eq!(src.shape(), Shape::new([]));
@@ -53,8 +53,8 @@ fn test_add() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let lhs = Node::from_scalar(&hw, &g, 1.);
-    let rhs = Node::from_scalar(&hw, &g, 2.);
+    let lhs = Node::from_scalar(&g, &hw, 1.);
+    let rhs = Node::from_scalar(&g, &hw, 2.);
     let ret = lhs + rhs;
 
     assert_eq!(lhs.shape(), Shape::new([]));
@@ -72,8 +72,8 @@ fn test_sub() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let lhs = Node::from_scalar(&hw, &g, 1.);
-    let rhs = Node::from_scalar(&hw, &g, 2.);
+    let lhs = Node::from_scalar(&g, &hw, 1.);
+    let rhs = Node::from_scalar(&g, &hw, 2.);
     let ret = lhs - rhs;
 
     assert_eq!(lhs.shape(), Shape::new([]));
@@ -91,8 +91,8 @@ fn test_mul() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let lhs = Node::from_scalar(&hw, &g, 1.);
-    let rhs = Node::from_scalar(&hw, &g, 2.);
+    let lhs = Node::from_scalar(&g, &hw, 1.);
+    let rhs = Node::from_scalar(&g, &hw, 2.);
     let ret = lhs * rhs;
 
     assert_eq!(lhs.shape(), Shape::new([]));
@@ -110,8 +110,8 @@ fn test_div() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let lhs = Node::from_scalar(&hw, &g, 1.);
-    let rhs = Node::from_scalar(&hw, &g, 2.);
+    let lhs = Node::from_scalar(&g, &hw, 1.);
+    let rhs = Node::from_scalar(&g, &hw, 2.);
     let ret = lhs / rhs;
 
     assert_eq!(lhs.shape(), Shape::new([]));
@@ -128,7 +128,7 @@ fn test_div() {
 fn test_fill_scalar() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
-    let ret = Node::fill(&hw, &g, Shape::new([]), 123.);
+    let ret = Node::fill(&g, &hw, Shape::new([]), 123.);
     assert_eq!(ret.shape(), Shape::new([]));
     assert!(ptr::eq(ret.hardware(), &hw));
     assert_eq!(ret.calculate().unwrap().get_scalar_f32(), Ok(123.));
@@ -138,7 +138,7 @@ fn test_fill_scalar() {
 fn test_fill_0() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
-    let ret = Node::fill(&hw, &g, Shape::new([0]), 123.);
+    let ret = Node::fill(&g, &hw, Shape::new([0]), 123.);
     assert_eq!(ret.shape(), Shape::new([0]));
     assert!(ptr::eq(ret.hardware(), &hw));
     assert_eq!(ret.calculate().unwrap().get_values_f32(), vec![]);
@@ -148,7 +148,7 @@ fn test_fill_0() {
 fn test_fill_n() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
-    let ret = Node::fill(&hw, &g, Shape::new([3]), 123.);
+    let ret = Node::fill(&g, &hw, Shape::new([3]), 123.);
     assert_eq!(ret.shape(), Shape::new([3]));
     assert!(ptr::eq(ret.hardware(), &hw));
     assert_eq!(
@@ -162,9 +162,9 @@ fn test_multiple_computation() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let a = Node::from_scalar(&hw, &g, 1.);
-    let b = Node::from_scalar(&hw, &g, 2.);
-    let c = Node::from_scalar(&hw, &g, 3.);
+    let a = Node::from_scalar(&g, &hw, 1.);
+    let b = Node::from_scalar(&g, &hw, 2.);
+    let c = Node::from_scalar(&g, &hw, 3.);
     let y = a + -b * c;
 
     assert_eq!(a.shape(), Shape::new([]));


### PR DESCRIPTION
This pr changes the order of arguments of some functions that takes both `Graph` and `Hardware`. Such functions return `Node`s which belong to a `Graph` passed to the function and making the `Graph` the first parameter (like `self`) is more suitable for its semantics.