### PR TITLE
Implements `TryFrom<Node> for f32`

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -25,8 +25,8 @@ impl<'hw: 'op, 'op: 'g, 'g> Node<'hw, 'op, 'g> {
     }
 
     pub fn from_scalar(
-        hardware: &'hw RefCell<dyn Hardware>,
         graph: &'g RefCell<Graph<'hw, 'op>>,
+        hardware: &'hw RefCell<dyn Hardware>,
         value: f32,
     ) -> Self {
         Self::new(
@@ -91,13 +91,13 @@ impl<'hw: 'op, 'op: 'g, 'g> Node<'hw, 'op, 'g> {
     ///
     /// # Arguments
     ///
-    /// * `hardware` - `Hardware` object to hold the value.
     /// * `graph` - `Graph` object to register the operation.
+    /// * `hardware` - `Hardware` object to hold the value.
     /// * `shape` - `Shape` of the output array.
     /// * `value` - Value of each element in the output array.
     pub fn fill(
-        hardware: &'hw RefCell<dyn Hardware>,
         graph: &'g RefCell<Graph<'hw, 'op>>,
+        hardware: &'hw RefCell<dyn Hardware>,
         shape: Shape,
         value: f32,
     ) -> Self {
@@ -273,7 +273,7 @@ pub fn grad<'hw, 'op, 'g>(
 
     // Assigns the gradient of `y` == 1.
     *(unsafe { gradients.get_unchecked_mut(last_step_id) }) =
-        Some(Node::fill(y.hardware(), g, y.shape(), 1.));
+        Some(Node::fill(g, y.hardware(), y.shape(), 1.));
 
     // Performs backpropagation.
     for step_id in ((first_step_id + 1)..=last_step_id).rev() {
@@ -318,7 +318,7 @@ pub fn grad<'hw, 'op, 'g>(
                 Some(grad_node) => *grad_node,
                 // No gradient propagation occurred for this node,
                 // assuming that the gradient is 0.
-                None => Node::fill(node.hardware(), g, node.shape(), 0.),
+                None => Node::fill(g, node.hardware(), node.shape(), 0.),
             }
         })
         .collect::<Vec<_>>()

--- a/src/node.rs
+++ b/src/node.rs
@@ -128,12 +128,7 @@ impl<'hw: 'op, 'op: 'g, 'g> Eq for Node<'hw, 'op, 'g> {}
 /// Directly obtaining a scalar value from a node.
 impl<'hw: 'op, 'op: 'g, 'g> From<Node<'hw, 'op, 'g>> for f32 {
     fn from(node: Node<'hw, 'op, 'g>) -> Self {
-        node.graph
-            .borrow_mut()
-            .calculate(node.step_id)
-            .unwrap()
-            .get_scalar_f32()
-            .unwrap()
+        node.calculate().unwrap().get_scalar_f32().unwrap()
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -3,7 +3,6 @@ use crate::error::Error;
 use crate::graph::Graph;
 use crate::hardware::Hardware;
 use crate::operator;
-use crate::result::Result;
 use crate::shape::Shape;
 use std::cell::RefCell;
 use std::fmt;
@@ -43,7 +42,10 @@ impl<'hw: 'op, 'op: 'g, 'g> Node<'hw, 'op, 'g> {
         )
     }
 
-    pub fn check_graph(&self, others: &[&Self]) -> Result<&'g RefCell<Graph<'hw, 'op>>> {
+    pub fn check_graph(
+        &self,
+        others: &[&Self],
+    ) -> crate::result::Result<&'g RefCell<Graph<'hw, 'op>>> {
         others
             .iter()
             .all(|&o| ptr::eq(self.graph, o.graph))
@@ -74,7 +76,7 @@ impl<'hw: 'op, 'op: 'g, 'g> Node<'hw, 'op, 'g> {
             .hardware()
     }
 
-    pub fn calculate(&self) -> Result<Array<'hw>> {
+    pub fn calculate(&self) -> crate::result::Result<Array<'hw>> {
         self.graph.borrow_mut().calculate(self.step_id)
     }
 
@@ -126,9 +128,10 @@ impl<'hw: 'op, 'op: 'g, 'g> PartialEq for Node<'hw, 'op, 'g> {
 impl<'hw: 'op, 'op: 'g, 'g> Eq for Node<'hw, 'op, 'g> {}
 
 /// Directly obtaining a scalar value from a node.
-impl<'hw: 'op, 'op: 'g, 'g> From<Node<'hw, 'op, 'g>> for f32 {
-    fn from(node: Node<'hw, 'op, 'g>) -> Self {
-        node.calculate().unwrap().get_scalar_f32().unwrap()
+impl<'hw: 'op, 'op: 'g, 'g> TryFrom<Node<'hw, 'op, 'g>> for f32 {
+    type Error = crate::error::Error;
+    fn try_from(node: Node<'hw, 'op, 'g>) -> Result<Self, Self::Error> {
+        node.calculate()?.get_scalar_f32()
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -3,6 +3,7 @@ use crate::error::Error;
 use crate::graph::Graph;
 use crate::hardware::Hardware;
 use crate::operator;
+use crate::result::Result;
 use crate::shape::Shape;
 use std::cell::RefCell;
 use std::fmt;
@@ -42,10 +43,7 @@ impl<'hw: 'op, 'op: 'g, 'g> Node<'hw, 'op, 'g> {
         )
     }
 
-    pub fn check_graph(
-        &self,
-        others: &[&Self],
-    ) -> crate::result::Result<&'g RefCell<Graph<'hw, 'op>>> {
+    pub fn check_graph(&self, others: &[&Self]) -> Result<&'g RefCell<Graph<'hw, 'op>>> {
         others
             .iter()
             .all(|&o| ptr::eq(self.graph, o.graph))
@@ -76,7 +74,7 @@ impl<'hw: 'op, 'op: 'g, 'g> Node<'hw, 'op, 'g> {
             .hardware()
     }
 
-    pub fn calculate(&self) -> crate::result::Result<Array<'hw>> {
+    pub fn calculate(&self) -> Result<Array<'hw>> {
         self.graph.borrow_mut().calculate(self.step_id)
     }
 
@@ -129,8 +127,8 @@ impl<'hw: 'op, 'op: 'g, 'g> Eq for Node<'hw, 'op, 'g> {}
 
 /// Directly obtaining a scalar value from a node.
 impl<'hw: 'op, 'op: 'g, 'g> TryFrom<Node<'hw, 'op, 'g>> for f32 {
-    type Error = crate::error::Error;
-    fn try_from(node: Node<'hw, 'op, 'g>) -> Result<Self, Self::Error> {
+    type Error = Error;
+    fn try_from(node: Node<'hw, 'op, 'g>) -> Result<Self> {
         node.calculate()?.get_scalar_f32()
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -43,15 +43,6 @@ impl<'hw: 'op, 'op: 'g, 'g> Node<'hw, 'op, 'g> {
         )
     }
 
-    pub fn to_scalar(&self) -> f32 {
-        self.graph
-            .borrow_mut()
-            .calculate(self.step_id)
-            .unwrap()
-            .get_scalar_f32()
-            .unwrap()
-    }
-
     pub fn check_graph(&self, others: &[&Self]) -> Result<&'g RefCell<Graph<'hw, 'op>>> {
         others
             .iter()
@@ -133,6 +124,18 @@ impl<'hw: 'op, 'op: 'g, 'g> PartialEq for Node<'hw, 'op, 'g> {
 }
 
 impl<'hw: 'op, 'op: 'g, 'g> Eq for Node<'hw, 'op, 'g> {}
+
+/// Directly obtaining a scalar value from a node.
+impl<'hw: 'op, 'op: 'g, 'g> From<Node<'hw, 'op, 'g>> for f32 {
+    fn from(node: Node<'hw, 'op, 'g>) -> Self {
+        node.graph
+            .borrow_mut()
+            .calculate(node.step_id)
+            .unwrap()
+            .get_scalar_f32()
+            .unwrap()
+    }
+}
 
 /// Unary "-" operator for `Node`.
 impl<'hw: 'op, 'op: 'g, 'g> std::ops::Neg for Node<'hw, 'op, 'g> {

--- a/src/node/grad_tests.rs
+++ b/src/node/grad_tests.rs
@@ -26,7 +26,7 @@ fn test_self() {
     assert!(ptr::eq(gx[0].hardware(), &hw));
 
     // dx/dx == 1
-    assert_eq!(f32::from(gx[0]), 1.);
+    assert_eq!(f32::try_from(gx[0]), Ok(1.));
 }
 
 #[test]
@@ -44,7 +44,7 @@ fn test_unrelated() {
     assert!(ptr::eq(gx[0].hardware(), &hw));
 
     // dy/dx == 0 since y is not calculated by x.
-    assert_eq!(f32::from(gx[0]), 0.);
+    assert_eq!(f32::try_from(gx[0]), Ok(0.));
 }
 
 #[test]
@@ -62,7 +62,7 @@ fn test_neg() {
     assert!(ptr::eq(gx[0].hardware(), &hw));
 
     // dy/dx == -1
-    assert_eq!(f32::from(gx[0]), -1.);
+    assert_eq!(f32::try_from(gx[0]), Ok(-1.));
 }
 
 #[test]
@@ -83,9 +83,9 @@ fn test_add() {
     assert!(ptr::eq(gx[1].hardware(), &hw));
 
     // dy/da == 1
-    assert_eq!(f32::from(gx[0]), 1.);
+    assert_eq!(f32::try_from(gx[0]), Ok(1.));
     // dy/db == 1
-    assert_eq!(f32::from(gx[1]), 1.);
+    assert_eq!(f32::try_from(gx[1]), Ok(1.));
 }
 
 #[test]
@@ -106,9 +106,9 @@ fn test_sub() {
     assert!(ptr::eq(gx[1].hardware(), &hw));
 
     // dy/da == 1
-    assert_eq!(f32::from(gx[0]), 1.);
+    assert_eq!(f32::try_from(gx[0]), Ok(1.));
     // dy/db == -1
-    assert_eq!(f32::from(gx[1]), -1.);
+    assert_eq!(f32::try_from(gx[1]), Ok(-1.));
 }
 
 #[test]
@@ -129,9 +129,9 @@ fn test_mul() {
     assert!(ptr::eq(gx[1].hardware(), &hw));
 
     // dy/da == b
-    assert_eq!(f32::from(gx[0]), 456.);
+    assert_eq!(f32::try_from(gx[0]), Ok(456.));
     // dy/db == a
-    assert_eq!(f32::from(gx[1]), 123.);
+    assert_eq!(f32::try_from(gx[1]), Ok(123.));
 }
 
 #[test]
@@ -151,7 +151,7 @@ fn test_mul_quadratic() {
     assert!(ptr::eq(gx[0].hardware(), &hw));
 
     // dy/dx == 2x, internally calculated by x + x.
-    assert_eq!(f32::from(gx[0]), 246.);
+    assert_eq!(f32::try_from(gx[0]), Ok(246.));
 }
 
 #[test]
@@ -172,9 +172,9 @@ fn test_div() {
     assert!(ptr::eq(gx[1].hardware(), &hw));
 
     // dy/da == 1/b
-    assert_eq!(f32::from(gx[0]), 0.5);
+    assert_eq!(f32::try_from(gx[0]), Ok(0.5));
     // dy/db == -a/b^2
-    assert_eq!(f32::from(gx[1]), -0.75);
+    assert_eq!(f32::try_from(gx[1]), Ok(-0.75));
 }
 
 #[test]
@@ -198,11 +198,11 @@ fn test_multiple_computation() {
     assert!(ptr::eq(gx[2].hardware(), &hw));
 
     // dy/da == 1
-    assert_eq!(f32::from(gx[0]), 1.);
+    assert_eq!(f32::try_from(gx[0]), Ok(1.));
     // dy/db == -c
-    assert_eq!(f32::from(gx[1]), -3.);
+    assert_eq!(f32::try_from(gx[1]), Ok(-3.));
     // dy/dc = -b
-    assert_eq!(f32::from(gx[2]), -2.);
+    assert_eq!(f32::try_from(gx[2]), Ok(-2.));
 }
 
 #[test]
@@ -228,13 +228,13 @@ fn test_higher_order_gradients() {
     assert!(ptr::eq(gx4.hardware(), &hw));
 
     // y' == dy/dx == 3x^2
-    assert_eq!(f32::from(gx1), 75.);
+    assert_eq!(f32::try_from(gx1), Ok(75.));
     // y'' == 6x
-    assert_eq!(f32::from(gx2), 30.);
+    assert_eq!(f32::try_from(gx2), Ok(30.));
     // y''' == 6
-    assert_eq!(f32::from(gx3), 6.);
+    assert_eq!(f32::try_from(gx3), Ok(6.));
     // y'''' == 0
-    assert_eq!(f32::from(gx4), 0.);
+    assert_eq!(f32::try_from(gx4), Ok(0.));
 }
 
 #[test]
@@ -263,22 +263,22 @@ fn test_gradient_of_multiple_variables() {
     let y_bba = grad(y_bb, &[a])[0];
     let y_bbb = grad(y_bb, &[b])[0];
 
-    assert_eq!(f32::from(y_a), 12.); // 2ab
-    assert_eq!(f32::from(y_b), 4.); // a^2
+    assert_eq!(f32::try_from(y_a), Ok(12.)); // 2ab
+    assert_eq!(f32::try_from(y_b), Ok(4.)); // a^2
 
-    assert_eq!(f32::from(y_aa), 6.); // 2b
-    assert_eq!(f32::from(y_ab), 4.); // 2a
-    assert_eq!(f32::from(y_ba), 4.); // 2a
-    assert_eq!(f32::from(y_bb), 0.); // 0
+    assert_eq!(f32::try_from(y_aa), Ok(6.)); // 2b
+    assert_eq!(f32::try_from(y_ab), Ok(4.)); // 2a
+    assert_eq!(f32::try_from(y_ba), Ok(4.)); // 2a
+    assert_eq!(f32::try_from(y_bb), Ok(0.)); // 0
 
-    assert_eq!(f32::from(y_aaa), 0.); // 0
-    assert_eq!(f32::from(y_aab), 2.); // 2
-    assert_eq!(f32::from(y_aba), 2.); // 2
-    assert_eq!(f32::from(y_abb), 0.); // 0
-    assert_eq!(f32::from(y_baa), 2.); // 2
-    assert_eq!(f32::from(y_bab), 0.); // 0
-    assert_eq!(f32::from(y_bba), 0.); // 0
-    assert_eq!(f32::from(y_bbb), 0.); // 0
+    assert_eq!(f32::try_from(y_aaa), Ok(0.)); // 0
+    assert_eq!(f32::try_from(y_aab), Ok(2.)); // 2
+    assert_eq!(f32::try_from(y_aba), Ok(2.)); // 2
+    assert_eq!(f32::try_from(y_abb), Ok(0.)); // 0
+    assert_eq!(f32::try_from(y_baa), Ok(2.)); // 2
+    assert_eq!(f32::try_from(y_bab), Ok(0.)); // 0
+    assert_eq!(f32::try_from(y_bba), Ok(0.)); // 0
+    assert_eq!(f32::try_from(y_bbb), Ok(0.)); // 0
 }
 
 #[test]

--- a/src/node/grad_tests.rs
+++ b/src/node/grad_tests.rs
@@ -26,7 +26,7 @@ fn test_self() {
     assert!(ptr::eq(gx[0].hardware(), &hw));
 
     // dx/dx == 1
-    assert_eq!(gx[0].calculate().unwrap().get_scalar_f32(), Ok(1.));
+    assert_eq!(f32::from(gx[0]), 1.);
 }
 
 #[test]
@@ -44,7 +44,7 @@ fn test_unrelated() {
     assert!(ptr::eq(gx[0].hardware(), &hw));
 
     // dy/dx == 0 since y is not calculated by x.
-    assert_eq!(gx[0].calculate().unwrap().get_scalar_f32(), Ok(0.));
+    assert_eq!(f32::from(gx[0]), 0.);
 }
 
 #[test]
@@ -62,7 +62,7 @@ fn test_neg() {
     assert!(ptr::eq(gx[0].hardware(), &hw));
 
     // dy/dx == -1
-    assert_eq!(gx[0].calculate().unwrap().get_scalar_f32(), Ok(-1.));
+    assert_eq!(f32::from(gx[0]), -1.);
 }
 
 #[test]
@@ -83,9 +83,9 @@ fn test_add() {
     assert!(ptr::eq(gx[1].hardware(), &hw));
 
     // dy/da == 1
-    assert_eq!(gx[0].calculate().unwrap().get_scalar_f32(), Ok(1.));
+    assert_eq!(f32::from(gx[0]), 1.);
     // dy/db == 1
-    assert_eq!(gx[1].calculate().unwrap().get_scalar_f32(), Ok(1.));
+    assert_eq!(f32::from(gx[1]), 1.);
 }
 
 #[test]
@@ -106,9 +106,9 @@ fn test_sub() {
     assert!(ptr::eq(gx[1].hardware(), &hw));
 
     // dy/da == 1
-    assert_eq!(gx[0].calculate().unwrap().get_scalar_f32(), Ok(1.));
+    assert_eq!(f32::from(gx[0]), 1.);
     // dy/db == -1
-    assert_eq!(gx[1].calculate().unwrap().get_scalar_f32(), Ok(-1.));
+    assert_eq!(f32::from(gx[1]), -1.);
 }
 
 #[test]
@@ -129,9 +129,9 @@ fn test_mul() {
     assert!(ptr::eq(gx[1].hardware(), &hw));
 
     // dy/da == b
-    assert_eq!(gx[0].calculate().unwrap().get_scalar_f32(), Ok(456.));
+    assert_eq!(f32::from(gx[0]), 456.);
     // dy/db == a
-    assert_eq!(gx[1].calculate().unwrap().get_scalar_f32(), Ok(123.));
+    assert_eq!(f32::from(gx[1]), 123.);
 }
 
 #[test]
@@ -151,7 +151,7 @@ fn test_mul_quadratic() {
     assert!(ptr::eq(gx[0].hardware(), &hw));
 
     // dy/dx == 2x, internally calculated by x + x.
-    assert_eq!(gx[0].calculate().unwrap().get_scalar_f32(), Ok(246.));
+    assert_eq!(f32::from(gx[0]), 246.);
 }
 
 #[test]
@@ -172,9 +172,9 @@ fn test_div() {
     assert!(ptr::eq(gx[1].hardware(), &hw));
 
     // dy/da == 1/b
-    assert_eq!(gx[0].calculate().unwrap().get_scalar_f32(), Ok(0.5));
+    assert_eq!(f32::from(gx[0]), 0.5);
     // dy/db == -a/b^2
-    assert_eq!(gx[1].calculate().unwrap().get_scalar_f32(), Ok(-0.75));
+    assert_eq!(f32::from(gx[1]), -0.75);
 }
 
 #[test]
@@ -198,11 +198,11 @@ fn test_multiple_computation() {
     assert!(ptr::eq(gx[2].hardware(), &hw));
 
     // dy/da == 1
-    assert_eq!(gx[0].calculate().unwrap().get_scalar_f32(), Ok(1.));
+    assert_eq!(f32::from(gx[0]), 1.);
     // dy/db == -c
-    assert_eq!(gx[1].calculate().unwrap().get_scalar_f32(), Ok(-3.));
+    assert_eq!(f32::from(gx[1]), -3.);
     // dy/dc = -b
-    assert_eq!(gx[2].calculate().unwrap().get_scalar_f32(), Ok(-2.));
+    assert_eq!(f32::from(gx[2]), -2.);
 }
 
 #[test]
@@ -228,13 +228,13 @@ fn test_higher_order_gradients() {
     assert!(ptr::eq(gx4.hardware(), &hw));
 
     // y' == dy/dx == 3x^2
-    assert_eq!(gx1.calculate().unwrap().get_scalar_f32(), Ok(75.));
+    assert_eq!(f32::from(gx1), 75.);
     // y'' == 6x
-    assert_eq!(gx2.calculate().unwrap().get_scalar_f32(), Ok(30.));
+    assert_eq!(f32::from(gx2), 30.);
     // y''' == 6
-    assert_eq!(gx3.calculate().unwrap().get_scalar_f32(), Ok(6.));
+    assert_eq!(f32::from(gx3), 6.);
     // y'''' == 0
-    assert_eq!(gx4.calculate().unwrap().get_scalar_f32(), Ok(0.));
+    assert_eq!(f32::from(gx4), 0.);
 }
 
 #[test]
@@ -263,22 +263,22 @@ fn test_gradient_of_multiple_variables() {
     let y_bba = grad(y_bb, &[a])[0];
     let y_bbb = grad(y_bb, &[b])[0];
 
-    assert_eq!(y_a.calculate().unwrap().get_scalar_f32(), Ok(12.)); // 2ab
-    assert_eq!(y_b.calculate().unwrap().get_scalar_f32(), Ok(4.)); // a^2
+    assert_eq!(f32::from(y_a), 12.); // 2ab
+    assert_eq!(f32::from(y_b), 4.); // a^2
 
-    assert_eq!(y_aa.calculate().unwrap().get_scalar_f32(), Ok(6.)); // 2b
-    assert_eq!(y_ab.calculate().unwrap().get_scalar_f32(), Ok(4.)); // 2a
-    assert_eq!(y_ba.calculate().unwrap().get_scalar_f32(), Ok(4.)); // 2a
-    assert_eq!(y_bb.calculate().unwrap().get_scalar_f32(), Ok(0.)); // 0
+    assert_eq!(f32::from(y_aa), 6.); // 2b
+    assert_eq!(f32::from(y_ab), 4.); // 2a
+    assert_eq!(f32::from(y_ba), 4.); // 2a
+    assert_eq!(f32::from(y_bb), 0.); // 0
 
-    assert_eq!(y_aaa.calculate().unwrap().get_scalar_f32(), Ok(0.)); // 0
-    assert_eq!(y_aab.calculate().unwrap().get_scalar_f32(), Ok(2.)); // 2
-    assert_eq!(y_aba.calculate().unwrap().get_scalar_f32(), Ok(2.)); // 2
-    assert_eq!(y_abb.calculate().unwrap().get_scalar_f32(), Ok(0.)); // 0
-    assert_eq!(y_baa.calculate().unwrap().get_scalar_f32(), Ok(2.)); // 2
-    assert_eq!(y_bab.calculate().unwrap().get_scalar_f32(), Ok(0.)); // 0
-    assert_eq!(y_bba.calculate().unwrap().get_scalar_f32(), Ok(0.)); // 0
-    assert_eq!(y_bbb.calculate().unwrap().get_scalar_f32(), Ok(0.)); // 0
+    assert_eq!(f32::from(y_aaa), 0.); // 0
+    assert_eq!(f32::from(y_aab), 2.); // 2
+    assert_eq!(f32::from(y_aba), 2.); // 2
+    assert_eq!(f32::from(y_abb), 0.); // 0
+    assert_eq!(f32::from(y_baa), 2.); // 2
+    assert_eq!(f32::from(y_bab), 0.); // 0
+    assert_eq!(f32::from(y_bba), 0.); // 0
+    assert_eq!(f32::from(y_bbb), 0.); // 0
 }
 
 #[test]

--- a/src/node/grad_tests.rs
+++ b/src/node/grad_tests.rs
@@ -6,7 +6,7 @@ fn test_empty() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let x = Node::from_scalar(&hw, &g, 42.);
+    let x = Node::from_scalar(&g, &hw, 42.);
 
     let gx = grad(x, &[]);
     assert!(gx.is_empty());
@@ -17,7 +17,7 @@ fn test_self() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let x = Node::from_scalar(&hw, &g, 42.);
+    let x = Node::from_scalar(&g, &hw, 42.);
 
     let gx = grad(x, &[x]);
     assert_eq!(gx.len(), 1);
@@ -34,8 +34,8 @@ fn test_unrelated() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let x = Node::from_scalar(&hw, &g, 42.);
-    let y = Node::from_scalar(&hw, &g, 42.);
+    let x = Node::from_scalar(&g, &hw, 42.);
+    let y = Node::from_scalar(&g, &hw, 42.);
 
     let gx = grad(y, &[x]);
     assert_eq!(gx.len(), 1);
@@ -52,7 +52,7 @@ fn test_neg() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let x = Node::from_scalar(&hw, &g, 42.);
+    let x = Node::from_scalar(&g, &hw, 42.);
     let y = -x;
 
     let gx = grad(y, &[x]);
@@ -70,8 +70,8 @@ fn test_add() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let a = Node::from_scalar(&hw, &g, 123.);
-    let b = Node::from_scalar(&hw, &g, 456.);
+    let a = Node::from_scalar(&g, &hw, 123.);
+    let b = Node::from_scalar(&g, &hw, 456.);
     let y = a + b;
 
     let gx = grad(y, &[a, b]);
@@ -93,8 +93,8 @@ fn test_sub() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let a = Node::from_scalar(&hw, &g, 123.);
-    let b = Node::from_scalar(&hw, &g, 456.);
+    let a = Node::from_scalar(&g, &hw, 123.);
+    let b = Node::from_scalar(&g, &hw, 456.);
     let y = a - b;
 
     let gx = grad(y, &[a, b]);
@@ -116,8 +116,8 @@ fn test_mul() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let a = Node::from_scalar(&hw, &g, 123.);
-    let b = Node::from_scalar(&hw, &g, 456.);
+    let a = Node::from_scalar(&g, &hw, 123.);
+    let b = Node::from_scalar(&g, &hw, 456.);
     let y = a * b;
 
     let gx = grad(y, &[a, b]);
@@ -139,7 +139,7 @@ fn test_mul_quadratic() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let x = Node::from_scalar(&hw, &g, 123.);
+    let x = Node::from_scalar(&g, &hw, 123.);
     // This calculation generates a diamond dependency between x and y
     // so that gradient summation x + x is happened during backpropagation.
     let y = x * x;
@@ -159,8 +159,8 @@ fn test_div() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let a = Node::from_scalar(&hw, &g, 3.);
-    let b = Node::from_scalar(&hw, &g, 2.);
+    let a = Node::from_scalar(&g, &hw, 3.);
+    let b = Node::from_scalar(&g, &hw, 2.);
     let y = a / b;
 
     let gx = grad(y, &[a, b]);
@@ -182,9 +182,9 @@ fn test_multiple_computation() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let a = Node::from_scalar(&hw, &g, 1.);
-    let b = Node::from_scalar(&hw, &g, 2.);
-    let c = Node::from_scalar(&hw, &g, 3.);
+    let a = Node::from_scalar(&g, &hw, 1.);
+    let b = Node::from_scalar(&g, &hw, 2.);
+    let c = Node::from_scalar(&g, &hw, 3.);
     let y = a + -b * c;
 
     let gx = grad(y, &[a, b, c]);
@@ -210,7 +210,7 @@ fn test_higher_order_gradients() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let x = Node::from_scalar(&hw, &g, 5.);
+    let x = Node::from_scalar(&g, &hw, 5.);
     let y = x * x * x;
 
     let gx1 = grad(y, &[x])[0];
@@ -242,8 +242,8 @@ fn test_gradient_of_multiple_variables() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let a = Node::from_scalar(&hw, &g, 2.);
-    let b = Node::from_scalar(&hw, &g, 3.);
+    let a = Node::from_scalar(&g, &hw, 2.);
+    let b = Node::from_scalar(&g, &hw, 3.);
     let y = a * a * b;
 
     let y_a = grad(y, &[a])[0];
@@ -288,7 +288,7 @@ fn test_different_graph() {
     let g1 = RefCell::new(Graph::new());
     let g2 = RefCell::new(Graph::new());
 
-    let x = Node::from_scalar(&hw, &g1, 2.);
-    let y = Node::from_scalar(&hw, &g2, 3.);
+    let x = Node::from_scalar(&g1, &hw, 2.);
+    let y = Node::from_scalar(&g2, &hw, 3.);
     let _gx = grad(y, &[x])[0];
 }

--- a/src/node/tests.rs
+++ b/src/node/tests.rs
@@ -102,7 +102,7 @@ fn test_mul() {
     assert!(ptr::eq(rhs.hardware(), &hw));
     assert!(ptr::eq(ret.hardware(), &hw));
 
-    assert_eq!(ret.calculate().unwrap().get_scalar_f32(), Ok(2.));
+    assert_eq!(f32::from(ret), 2.);
 }
 
 #[test]
@@ -121,7 +121,7 @@ fn test_div() {
     assert!(ptr::eq(rhs.hardware(), &hw));
     assert!(ptr::eq(ret.hardware(), &hw));
 
-    assert_eq!(ret.calculate().unwrap().get_scalar_f32(), Ok(0.5));
+    assert_eq!(f32::from(ret), 0.5);
 }
 
 #[test]
@@ -131,7 +131,7 @@ fn test_fill_scalar() {
     let ret = Node::fill(&g, &hw, Shape::new([]), 123.);
     assert_eq!(ret.shape(), Shape::new([]));
     assert!(ptr::eq(ret.hardware(), &hw));
-    assert_eq!(ret.calculate().unwrap().get_scalar_f32(), Ok(123.));
+    assert_eq!(f32::from(ret), 123.);
 }
 
 #[test]
@@ -176,5 +176,5 @@ fn test_multiple_computation() {
     assert!(ptr::eq(c.hardware(), &hw));
     assert!(ptr::eq(y.hardware(), &hw));
 
-    assert_eq!(y.calculate().unwrap().get_scalar_f32(), Ok(-5.));
+    assert_eq!(f32::from(y), -5.);
 }

--- a/src/node/tests.rs
+++ b/src/node/tests.rs
@@ -102,7 +102,7 @@ fn test_mul() {
     assert!(ptr::eq(rhs.hardware(), &hw));
     assert!(ptr::eq(ret.hardware(), &hw));
 
-    assert_eq!(f32::from(ret), 2.);
+    assert_eq!(f32::try_from(ret), Ok(2.));
 }
 
 #[test]
@@ -121,7 +121,7 @@ fn test_div() {
     assert!(ptr::eq(rhs.hardware(), &hw));
     assert!(ptr::eq(ret.hardware(), &hw));
 
-    assert_eq!(f32::from(ret), 0.5);
+    assert_eq!(f32::try_from(ret), Ok(0.5));
 }
 
 #[test]
@@ -131,7 +131,7 @@ fn test_fill_scalar() {
     let ret = Node::fill(&g, &hw, Shape::new([]), 123.);
     assert_eq!(ret.shape(), Shape::new([]));
     assert!(ptr::eq(ret.hardware(), &hw));
-    assert_eq!(f32::from(ret), 123.);
+    assert_eq!(f32::try_from(ret), Ok(123.));
 }
 
 #[test]
@@ -176,5 +176,5 @@ fn test_multiple_computation() {
     assert!(ptr::eq(c.hardware(), &hw));
     assert!(ptr::eq(y.hardware(), &hw));
 
-    assert_eq!(f32::from(y), -5.);
+    assert_eq!(f32::try_from(y), Ok(-5.));
 }

--- a/src/node/tests.rs
+++ b/src/node/tests.rs
@@ -5,8 +5,8 @@ use crate::node::*;
 fn test_steps() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
-    let lhs = Node::from_scalar(&hw, &g, 1.);
-    let rhs = Node::from_scalar(&hw, &g, 2.);
+    let lhs = Node::from_scalar(&g, &hw, 1.);
+    let rhs = Node::from_scalar(&g, &hw, 2.);
     let ret = lhs + rhs;
 
     assert_eq!(lhs, Node::new(&g, 0));
@@ -37,7 +37,7 @@ fn test_neg() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let src = Node::from_scalar(&hw, &g, 42.);
+    let src = Node::from_scalar(&g, &hw, 42.);
     let dest = -src;
 
     assert_eq!(src.shape(), Shape::new([]));
@@ -53,8 +53,8 @@ fn test_add() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let lhs = Node::from_scalar(&hw, &g, 1.);
-    let rhs = Node::from_scalar(&hw, &g, 2.);
+    let lhs = Node::from_scalar(&g, &hw, 1.);
+    let rhs = Node::from_scalar(&g, &hw, 2.);
     let ret = lhs + rhs;
 
     assert_eq!(lhs.shape(), Shape::new([]));
@@ -72,8 +72,8 @@ fn test_sub() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let lhs = Node::from_scalar(&hw, &g, 1.);
-    let rhs = Node::from_scalar(&hw, &g, 2.);
+    let lhs = Node::from_scalar(&g, &hw, 1.);
+    let rhs = Node::from_scalar(&g, &hw, 2.);
     let ret = lhs - rhs;
 
     assert_eq!(lhs.shape(), Shape::new([]));
@@ -91,8 +91,8 @@ fn test_mul() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let lhs = Node::from_scalar(&hw, &g, 1.);
-    let rhs = Node::from_scalar(&hw, &g, 2.);
+    let lhs = Node::from_scalar(&g, &hw, 1.);
+    let rhs = Node::from_scalar(&g, &hw, 2.);
     let ret = lhs * rhs;
 
     assert_eq!(lhs.shape(), Shape::new([]));
@@ -110,8 +110,8 @@ fn test_div() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let lhs = Node::from_scalar(&hw, &g, 1.);
-    let rhs = Node::from_scalar(&hw, &g, 2.);
+    let lhs = Node::from_scalar(&g, &hw, 1.);
+    let rhs = Node::from_scalar(&g, &hw, 2.);
     let ret = lhs / rhs;
 
     assert_eq!(lhs.shape(), Shape::new([]));
@@ -128,7 +128,7 @@ fn test_div() {
 fn test_fill_scalar() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
-    let ret = Node::fill(&hw, &g, Shape::new([]), 123.);
+    let ret = Node::fill(&g, &hw, Shape::new([]), 123.);
     assert_eq!(ret.shape(), Shape::new([]));
     assert!(ptr::eq(ret.hardware(), &hw));
     assert_eq!(ret.calculate().unwrap().get_scalar_f32(), Ok(123.));
@@ -138,7 +138,7 @@ fn test_fill_scalar() {
 fn test_fill_0() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
-    let ret = Node::fill(&hw, &g, Shape::new([0]), 123.);
+    let ret = Node::fill(&g, &hw, Shape::new([0]), 123.);
     assert_eq!(ret.shape(), Shape::new([0]));
     assert!(ptr::eq(ret.hardware(), &hw));
     assert_eq!(ret.calculate().unwrap().get_values_f32(), vec![]);
@@ -148,7 +148,7 @@ fn test_fill_0() {
 fn test_fill_n() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
-    let ret = Node::fill(&hw, &g, Shape::new([3]), 123.);
+    let ret = Node::fill(&g, &hw, Shape::new([3]), 123.);
     assert_eq!(ret.shape(), Shape::new([3]));
     assert!(ptr::eq(ret.hardware(), &hw));
     assert_eq!(
@@ -162,9 +162,9 @@ fn test_multiple_computation() {
     let hw = RefCell::new(CpuHardware::new());
     let g = RefCell::new(Graph::new());
 
-    let a = Node::from_scalar(&hw, &g, 1.);
-    let b = Node::from_scalar(&hw, &g, 2.);
-    let c = Node::from_scalar(&hw, &g, 3.);
+    let a = Node::from_scalar(&g, &hw, 1.);
+    let b = Node::from_scalar(&g, &hw, 2.);
+    let c = Node::from_scalar(&g, &hw, 3.);
     let y = a + -b * c;
 
     assert_eq!(a.shape(), Shape::new([]));


### PR DESCRIPTION
This pr adds `TryFrom<Node> for f32` which obtains scalar results by implicitly invoking the calculation.

Blocking change: #20