### PR TITLE
Simplify Graph::calculate()

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -186,11 +186,9 @@ impl<'hw: 'op, 'op> Graph<'hw, 'op> {
     /// # Returns
     ///
     /// * Calculated/cached value associated to `target`.
-    pub(crate) fn calculate(&mut self, target: usize) -> Result<Array<'hw>> {
+    pub(crate) fn calculate(&mut self, target: usize) -> Array<'hw> {
         // Avoiding an edge case: inner step_ids should be correct, but `target` is not constrained.
-        if target >= self.steps.len() {
-            return Err(Error::InvalidNode(format!("Invalid step ID: {}", target)));
-        }
+        assert!(target < self.steps.len(), "Invalid step ID: {}", target);
 
         // Actions for the push-down automaton representing the following procedure:
         /*
@@ -251,11 +249,11 @@ impl<'hw: 'op, 'op> Graph<'hw, 'op> {
         }
 
         // The `target` step must own a calculated value.
-        Ok(unsafe { self.steps.get_unchecked(target) }
+        unsafe { self.steps.get_unchecked(target) }
             .output
             .array()
             .unwrap()
-            .clone())
+            .clone()
     }
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -250,6 +250,7 @@ impl<'hw: 'op, 'op> Graph<'hw, 'op> {
             }
         }
 
+        // The `target` step must own a calculated value.
         Ok(unsafe { self.steps.get_unchecked(target) }
             .output
             .array()

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -250,13 +250,11 @@ impl<'hw: 'op, 'op> Graph<'hw, 'op> {
             }
         }
 
-        if let ArrayPlaceholder::Assigned(ref array) =
-            unsafe { self.steps.get_unchecked(target) }.output
-        {
-            return Ok(array.clone());
-        }
-
-        panic!("Target step could not be calculated for some reason.");
+        Ok(unsafe { self.steps.get_unchecked(target) }
+            .output
+            .array()
+            .unwrap()
+            .clone())
     }
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -186,7 +186,7 @@ impl<'hw: 'op, 'op> Graph<'hw, 'op> {
     /// # Returns
     ///
     /// * Calculated/cached value associated to `target`.
-    pub(crate) fn calculate(&mut self, target: usize) -> Array<'hw> {
+    pub(crate) fn calculate(&mut self, target: usize) -> &Array<'hw> {
         // Avoiding an edge case: inner step_ids should be correct, but `target` is not constrained.
         assert!(target < self.steps.len(), "Invalid step ID: {}", target);
 
@@ -253,7 +253,6 @@ impl<'hw: 'op, 'op> Graph<'hw, 'op> {
             .output
             .array()
             .unwrap()
-            .clone()
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -75,7 +75,7 @@ impl<'hw: 'op, 'op: 'g, 'g> Node<'hw, 'op, 'g> {
     }
 
     pub fn calculate(&self) -> Array<'hw> {
-        self.graph.borrow_mut().calculate(self.step_id)
+        self.graph.borrow_mut().calculate(self.step_id).clone()
     }
 
     /// Registers `Fill` operation to the graph.

--- a/src/node.rs
+++ b/src/node.rs
@@ -74,7 +74,7 @@ impl<'hw: 'op, 'op: 'g, 'g> Node<'hw, 'op, 'g> {
             .hardware()
     }
 
-    pub fn calculate(&self) -> crate::result::Result<Array<'hw>> {
+    pub fn calculate(&self) -> Array<'hw> {
         self.graph.borrow_mut().calculate(self.step_id)
     }
 
@@ -129,7 +129,7 @@ impl<'hw: 'op, 'op: 'g, 'g> Eq for Node<'hw, 'op, 'g> {}
 impl<'hw: 'op, 'op: 'g, 'g> TryFrom<Node<'hw, 'op, 'g>> for f32 {
     type Error = Error;
     fn try_from(node: Node<'hw, 'op, 'g>) -> Result<Self> {
-        node.calculate()?.get_scalar_f32()
+        node.calculate().get_scalar_f32()
     }
 }
 

--- a/src/node/tests.rs
+++ b/src/node/tests.rs
@@ -27,7 +27,7 @@ fn test_steps() {
         assert_eq!(g.get_step(2).unwrap().operator.name(), "Add");
     }
 
-    let retval = ret.calculate().unwrap();
+    let retval = ret.calculate();
     assert_eq!(*retval.shape(), Shape::new([]));
     assert_eq!(retval.get_scalar_f32(), Ok(3.));
 }
@@ -45,7 +45,7 @@ fn test_neg() {
     assert!(ptr::eq(src.hardware(), &hw));
     assert!(ptr::eq(dest.hardware(), &hw));
 
-    assert_eq!(dest.calculate().unwrap().get_scalar_f32(), Ok(-42.));
+    assert_eq!(dest.calculate().get_scalar_f32(), Ok(-42.));
 }
 
 #[test]
@@ -64,7 +64,7 @@ fn test_add() {
     assert!(ptr::eq(rhs.hardware(), &hw));
     assert!(ptr::eq(ret.hardware(), &hw));
 
-    assert_eq!(ret.calculate().unwrap().get_scalar_f32(), Ok(3.));
+    assert_eq!(ret.calculate().get_scalar_f32(), Ok(3.));
 }
 
 #[test]
@@ -83,7 +83,7 @@ fn test_sub() {
     assert!(ptr::eq(rhs.hardware(), &hw));
     assert!(ptr::eq(ret.hardware(), &hw));
 
-    assert_eq!(ret.calculate().unwrap().get_scalar_f32(), Ok(-1.));
+    assert_eq!(ret.calculate().get_scalar_f32(), Ok(-1.));
 }
 
 #[test]
@@ -141,7 +141,7 @@ fn test_fill_0() {
     let ret = Node::fill(&g, &hw, Shape::new([0]), 123.);
     assert_eq!(ret.shape(), Shape::new([0]));
     assert!(ptr::eq(ret.hardware(), &hw));
-    assert_eq!(ret.calculate().unwrap().get_values_f32(), vec![]);
+    assert_eq!(ret.calculate().get_values_f32(), vec![]);
 }
 
 #[test]
@@ -151,10 +151,7 @@ fn test_fill_n() {
     let ret = Node::fill(&g, &hw, Shape::new([3]), 123.);
     assert_eq!(ret.shape(), Shape::new([3]));
     assert!(ptr::eq(ret.hardware(), &hw));
-    assert_eq!(
-        ret.calculate().unwrap().get_values_f32(),
-        vec![123., 123., 123.]
-    );
+    assert_eq!(ret.calculate().get_values_f32(), vec![123., 123., 123.]);
 }
 
 #[test]


### PR DESCRIPTION
This change fixes two things in `Graph::calculate()`:
- Changes return type from `Result<Array>` to `&Array`:
  - Since this function is used only in the crate, any invalid invocation (= invoking the function with invalid step IDs) can be avoided.
  - Postpones cloning the value to `Node::calculate()`.
- Removes an unnecessary sentinel in the last step.