### PR TITLE
impl IntoArray for ndarray::ArrayN

### DIFF
--- a/src/array/convert_ndarray.rs
+++ b/src/array/convert_ndarray.rs
@@ -1,7 +1,7 @@
 use crate::array::*;
 
 // ndarray has separate definitions of Array0 - Array6 although they are based on some generics.
-// We also provide separate definitions of TryFrom<&Array> for each ArrayN to fit the same manner.
+// We also provide separate definitions of TryFrom<&Array> and IntoArray for each ArrayN to fit the same manner.
 
 macro_rules! define_into_array {
     ( $src_ty:ty ) => {

--- a/src/array/convert_ndarray.rs
+++ b/src/array/convert_ndarray.rs
@@ -3,9 +3,32 @@ use crate::array::*;
 // ndarray has separate definitions of Array0 - Array6 although they are based on some generics.
 // We also provide separate definitions of TryFrom<&Array> for each ArrayN to fit the same manner.
 
+macro_rules! define_into_array {
+    ( $src_ty:ty ) => {
+        impl IntoArray for $src_ty {
+            fn into_array(self, hardware: &RefCell<dyn Hardware>) -> Array {
+                Array::constant_f32(
+                    hardware,
+                    Shape::from_slice(self.shape()),
+                    self.as_standard_layout().as_slice().unwrap(),
+                )
+                .unwrap()
+            }
+        }
+    };
+}
+
+define_into_array!(&ndarray::Array0<f32>);
+define_into_array!(&ndarray::Array1<f32>);
+define_into_array!(&ndarray::Array2<f32>);
+define_into_array!(&ndarray::Array3<f32>);
+define_into_array!(&ndarray::Array4<f32>);
+define_into_array!(&ndarray::Array5<f32>);
+define_into_array!(&ndarray::Array6<f32>);
+
 macro_rules! define_try_from_array {
-    ( $as_array_fn:ident, $dest:ty ) => {
-        impl<'hw> TryFrom<&Array<'hw>> for $dest {
+    ( $as_array_fn:ident, $dest_ty:ty ) => {
+        impl<'hw> TryFrom<&Array<'hw>> for $dest_ty {
             type Error = Error;
             fn try_from(src: &Array<'hw>) -> Result<Self> {
                 let shape = src.shape.$as_array_fn()?;

--- a/src/array/convert_ndarray.rs
+++ b/src/array/convert_ndarray.rs
@@ -10,6 +10,7 @@ macro_rules! define_into_array {
                 Array::constant_f32(
                     hardware,
                     Shape::from_slice(self.shape()),
+                    // `Array` supports only data with the row-major order.
                     self.as_standard_layout().as_slice().unwrap(),
                 )
                 .unwrap()

--- a/src/array/convert_ndarray/tests.rs
+++ b/src/array/convert_ndarray/tests.rs
@@ -1,5 +1,6 @@
 use crate::array::*;
 use crate::hardware::cpu::CpuHardware;
+use ndarray::ShapeBuilder;
 
 #[test]
 fn test_try_into_ndarray0() {
@@ -189,4 +190,200 @@ fn test_try_into_ndarray6_fail() {
         let src = Array::fill_f32(&hw, Shape::from_slice(&vec![1; n]), 42.);
         assert!(ndarray::Array6::<f32>::try_from(&src).is_err());
     }
+}
+
+// Helper function to generate float range vector [0, end) with step size of 1.
+fn iota(end: i32) -> Vec<f32> {
+    (0..end).map(|x| x as f32).collect()
+}
+
+#[test]
+fn test_from_ndarray0() {
+    let hw = RefCell::new(CpuHardware::new());
+    let src = ndarray::arr0(123.);
+    let dest = src.into_array(&hw);
+    assert_eq!(*dest.shape(), Shape::new([]));
+    assert_eq!(dest.get_values_f32(), vec![123.]);
+}
+
+#[test]
+fn test_from_ndarray1() {
+    let hw = RefCell::new(CpuHardware::new());
+    let src = ndarray::arr1(&iota(3));
+    let dest = src.into_array(&hw);
+    assert_eq!(*dest.shape(), Shape::new([3]));
+    assert_eq!(dest.get_values_f32(), iota(3));
+}
+
+#[test]
+fn test_from_ndarray1_0() {
+    let hw = RefCell::new(CpuHardware::new());
+    let src = ndarray::arr1(&[]);
+    let dest = src.into_array(&hw);
+    assert_eq!(*dest.shape(), Shape::new([0]));
+    assert_eq!(dest.get_values_f32(), vec![]);
+}
+
+#[test]
+fn test_from_ndarray2() {
+    let hw = RefCell::new(CpuHardware::new());
+    let src = ndarray::Array2::<f32>::from_shape_vec((2, 2), iota(4)).unwrap();
+    let dest = src.into_array(&hw);
+    assert_eq!(*dest.shape(), Shape::new([2, 2]));
+    assert_eq!(dest.get_values_f32(), iota(4));
+}
+
+#[test]
+fn test_from_ndarray2_0() {
+    let hw = RefCell::new(CpuHardware::new());
+    let src = ndarray::Array2::<f32>::from_shape_vec((0, 0), vec![]).unwrap();
+    let dest = src.into_array(&hw);
+    assert_eq!(*dest.shape(), Shape::new([0, 0]));
+    assert_eq!(dest.get_values_f32(), vec![]);
+}
+
+#[test]
+fn test_from_ndarray2_f() {
+    let hw = RefCell::new(CpuHardware::new());
+    let src = ndarray::Array2::<f32>::from_shape_vec((2, 2).f(), iota(4)).unwrap();
+    let dest = src.into_array(&hw);
+    assert_eq!(*dest.shape(), Shape::new([2, 2]));
+    assert_eq!(dest.get_values_f32(), vec![0., 2., 1., 3.]);
+}
+
+#[test]
+fn test_from_ndarray3() {
+    let hw = RefCell::new(CpuHardware::new());
+    let src = ndarray::Array3::<f32>::from_shape_vec((2, 2, 2), iota(8)).unwrap();
+    let dest = src.into_array(&hw);
+    assert_eq!(*dest.shape(), Shape::new([2, 2, 2]));
+    assert_eq!(dest.get_values_f32(), iota(8));
+}
+
+#[test]
+fn test_from_ndarray3_0() {
+    let hw = RefCell::new(CpuHardware::new());
+    let src = ndarray::Array3::<f32>::from_shape_vec((0, 0, 0), vec![]).unwrap();
+    let dest = src.into_array(&hw);
+    assert_eq!(*dest.shape(), Shape::new([0, 0, 0]));
+    assert_eq!(dest.get_values_f32(), vec![]);
+}
+
+#[test]
+fn test_from_ndarray3_f() {
+    let hw = RefCell::new(CpuHardware::new());
+    let src = ndarray::Array3::<f32>::from_shape_vec((2, 2, 2).f(), iota(8)).unwrap();
+    let dest = src.into_array(&hw);
+    assert_eq!(*dest.shape(), Shape::new([2, 2, 2]));
+    assert_eq!(dest.get_values_f32(), vec![0., 4., 2., 6., 1., 5., 3., 7.]);
+}
+
+#[test]
+fn test_from_ndarray4() {
+    let hw = RefCell::new(CpuHardware::new());
+    let src = ndarray::Array4::<f32>::from_shape_vec((2, 2, 2, 2), iota(16)).unwrap();
+    let dest = src.into_array(&hw);
+    assert_eq!(*dest.shape(), Shape::new([2, 2, 2, 2]));
+    assert_eq!(dest.get_values_f32(), iota(16));
+}
+
+#[test]
+fn test_from_ndarray4_0() {
+    let hw = RefCell::new(CpuHardware::new());
+    let src = ndarray::Array4::<f32>::from_shape_vec((0, 0, 0, 0), vec![]).unwrap();
+    let dest = src.into_array(&hw);
+    assert_eq!(*dest.shape(), Shape::new([0, 0, 0, 0]));
+    assert_eq!(dest.get_values_f32(), vec![]);
+}
+
+#[test]
+fn test_from_ndarray4_f() {
+    let hw = RefCell::new(CpuHardware::new());
+    let src = ndarray::Array4::<f32>::from_shape_vec((2, 2, 2, 2).f(), iota(16)).unwrap();
+    let dest = src.into_array(&hw);
+    assert_eq!(*dest.shape(), Shape::new([2, 2, 2, 2]));
+    #[rustfmt::skip]
+    assert_eq!(
+        dest.get_values_f32(),
+        vec![
+            0., 8., 4., 12., 2., 10., 6., 14.,
+            1., 9., 5., 13., 3., 11., 7., 15.,
+        ]
+    );
+}
+
+#[test]
+fn test_from_ndarray5() {
+    let hw = RefCell::new(CpuHardware::new());
+    let src = ndarray::Array5::<f32>::from_shape_vec((2, 2, 2, 2, 2), iota(32)).unwrap();
+    let dest = src.into_array(&hw);
+    assert_eq!(*dest.shape(), Shape::new([2, 2, 2, 2, 2]));
+    assert_eq!(dest.get_values_f32(), iota(32));
+}
+
+#[test]
+fn test_from_ndarray5_0() {
+    let hw = RefCell::new(CpuHardware::new());
+    let src = ndarray::Array5::<f32>::from_shape_vec((0, 0, 0, 0, 0), vec![]).unwrap();
+    let dest = src.into_array(&hw);
+    assert_eq!(*dest.shape(), Shape::new([0, 0, 0, 0, 0]));
+    assert_eq!(dest.get_values_f32(), vec![]);
+}
+
+#[test]
+fn test_from_ndarray5_f() {
+    let hw = RefCell::new(CpuHardware::new());
+    let src = ndarray::Array5::<f32>::from_shape_vec((2, 2, 2, 2, 2).f(), iota(32)).unwrap();
+    let dest = src.into_array(&hw);
+    assert_eq!(*dest.shape(), Shape::new([2, 2, 2, 2, 2]));
+    #[rustfmt::skip]
+    assert_eq!(
+        dest.get_values_f32(),
+        vec![
+            0., 16.,  8., 24., 4., 20., 12., 28.,
+            2., 18., 10., 26., 6., 22., 14., 30.,
+            1., 17.,  9., 25., 5., 21., 13., 29.,
+            3., 19., 11., 27., 7., 23., 15., 31.,
+        ]
+    );
+}
+
+#[test]
+fn test_from_ndarray6() {
+    let hw = RefCell::new(CpuHardware::new());
+    let src = ndarray::Array6::<f32>::from_shape_vec((2, 2, 2, 2, 2, 2), iota(64)).unwrap();
+    let dest = src.into_array(&hw);
+    assert_eq!(*dest.shape(), Shape::new([2, 2, 2, 2, 2, 2]));
+    assert_eq!(dest.get_values_f32(), iota(64));
+}
+
+#[test]
+fn test_from_ndarray6_0() {
+    let hw = RefCell::new(CpuHardware::new());
+    let src = ndarray::Array6::<f32>::from_shape_vec((0, 0, 0, 0, 0, 0), vec![]).unwrap();
+    let dest = src.into_array(&hw);
+    assert_eq!(*dest.shape(), Shape::new([0, 0, 0, 0, 0, 0]));
+    assert_eq!(dest.get_values_f32(), vec![]);
+}
+
+#[test]
+fn test_from_ndarray6_f() {
+    let hw = RefCell::new(CpuHardware::new());
+    let src = ndarray::Array6::<f32>::from_shape_vec((2, 2, 2, 2, 2, 2).f(), iota(64)).unwrap();
+    let dest = src.into_array(&hw);
+    assert_eq!(*dest.shape(), Shape::new([2, 2, 2, 2, 2, 2]));
+    #[rustfmt::skip]
+    assert_eq!(
+        dest.get_values_f32(),
+        vec![
+            0., 32., 16., 48.,  8., 40., 24., 56.,
+            4., 36., 20., 52., 12., 44., 28., 60.,
+            2., 34., 18., 50., 10., 42., 26., 58.,
+            6., 38., 22., 54., 14., 46., 30., 62.,
+            1., 33., 17., 49.,  9., 41., 25., 57.,
+            5., 37., 21., 53., 13., 45., 29., 61.,
+            3., 35., 19., 51., 11., 43., 27., 59.,
+            7., 39., 23., 55., 15., 47., 31., 63.,
+        ]
+    );
 }

--- a/src/array/convert_ndarray/tests.rs
+++ b/src/array/convert_ndarray/tests.rs
@@ -2,15 +2,15 @@ use crate::array::*;
 use crate::hardware::cpu::CpuHardware;
 
 #[test]
-fn test_try_into_array0() {
+fn test_try_into_ndarray0() {
     let hw = RefCell::new(CpuHardware::new());
-    let src = Array::scalar_f32(&hw, 42.);
+    let src = 42f32.into_array(&hw);
     let dest = ndarray::Array0::<f32>::try_from(&src).unwrap();
     assert_eq!(dest, ndarray::arr0(42.));
 }
 
 #[test]
-fn test_try_into_array0_fail() {
+fn test_try_into_ndarray0_fail() {
     let hw = RefCell::new(CpuHardware::new());
     for n in [1, 2, 3, 4, 5, 6, 7, 8] {
         let src = Array::fill_f32(&hw, Shape::from_slice(&vec![1; n]), 42.);
@@ -19,7 +19,7 @@ fn test_try_into_array0_fail() {
 }
 
 #[test]
-fn test_try_into_array1_0() {
+fn test_try_into_ndarray1_0() {
     let hw = RefCell::new(CpuHardware::new());
     let src = Array::fill_f32(&hw, Shape::new([0]), 42.);
     let dest = ndarray::Array1::<f32>::try_from(&src).unwrap();
@@ -27,7 +27,7 @@ fn test_try_into_array1_0() {
 }
 
 #[test]
-fn test_try_into_array1_3() {
+fn test_try_into_ndarray1_3() {
     let hw = RefCell::new(CpuHardware::new());
     let src = Array::fill_f32(&hw, Shape::new([3]), 42.);
     let dest = ndarray::Array1::<f32>::try_from(&src).unwrap();
@@ -35,7 +35,7 @@ fn test_try_into_array1_3() {
 }
 
 #[test]
-fn test_try_into_array1_fail() {
+fn test_try_into_ndarray1_fail() {
     let hw = RefCell::new(CpuHardware::new());
     for n in [0, 2, 3, 4, 5, 6, 7, 8] {
         let src = Array::fill_f32(&hw, Shape::from_slice(&vec![1; n]), 42.);
@@ -44,7 +44,7 @@ fn test_try_into_array1_fail() {
 }
 
 #[test]
-fn test_try_into_array2_0x0() {
+fn test_try_into_ndarray2_0x0() {
     let hw = RefCell::new(CpuHardware::new());
     let src = Array::fill_f32(&hw, Shape::new([0, 0]), 42.);
     let dest = ndarray::Array2::<f32>::try_from(&src).unwrap();
@@ -52,7 +52,7 @@ fn test_try_into_array2_0x0() {
 }
 
 #[test]
-fn test_try_into_array2_2x3() {
+fn test_try_into_ndarray2_2x3() {
     let hw = RefCell::new(CpuHardware::new());
     let src = Array::fill_f32(&hw, Shape::new([2, 3]), 42.);
     let dest = ndarray::Array2::<f32>::try_from(&src).unwrap();
@@ -60,7 +60,7 @@ fn test_try_into_array2_2x3() {
 }
 
 #[test]
-fn test_try_into_array2_fail() {
+fn test_try_into_ndarray2_fail() {
     let hw = RefCell::new(CpuHardware::new());
     for n in [0, 1, 3, 4, 5, 6, 7, 8] {
         let src = Array::fill_f32(&hw, Shape::from_slice(&vec![1; n]), 42.);
@@ -69,7 +69,7 @@ fn test_try_into_array2_fail() {
 }
 
 #[test]
-fn test_try_into_array3_0x0x0() {
+fn test_try_into_ndarray3_0x0x0() {
     let hw = RefCell::new(CpuHardware::new());
     let src = Array::fill_f32(&hw, Shape::new([0, 0, 0]), 42.);
     let dest = ndarray::Array3::<f32>::try_from(&src).unwrap();
@@ -77,7 +77,7 @@ fn test_try_into_array3_0x0x0() {
 }
 
 #[test]
-fn test_try_into_array3_2x3x4() {
+fn test_try_into_ndarray3_2x3x4() {
     let hw = RefCell::new(CpuHardware::new());
     let src = Array::fill_f32(&hw, Shape::new([2, 3, 4]), 42.);
     let dest = ndarray::Array3::<f32>::try_from(&src).unwrap();
@@ -85,7 +85,7 @@ fn test_try_into_array3_2x3x4() {
 }
 
 #[test]
-fn test_try_into_array3_fail() {
+fn test_try_into_ndarray3_fail() {
     let hw = RefCell::new(CpuHardware::new());
     for n in [0, 1, 2, 4, 5, 6, 7, 8] {
         let src = Array::fill_f32(&hw, Shape::from_slice(&vec![1; n]), 42.);
@@ -94,7 +94,7 @@ fn test_try_into_array3_fail() {
 }
 
 #[test]
-fn test_try_into_array4_0x0x0x0() {
+fn test_try_into_ndarray4_0x0x0x0() {
     let hw = RefCell::new(CpuHardware::new());
     let src = Array::fill_f32(&hw, Shape::new([0, 0, 0, 0]), 42.);
     let dest = ndarray::Array4::<f32>::try_from(&src).unwrap();
@@ -105,7 +105,7 @@ fn test_try_into_array4_0x0x0x0() {
 }
 
 #[test]
-fn test_try_into_array4_2x3x4x5() {
+fn test_try_into_ndarray4_2x3x4x5() {
     let hw = RefCell::new(CpuHardware::new());
     let src = Array::fill_f32(&hw, Shape::new([2, 3, 4, 5]), 42.);
     let dest = ndarray::Array4::<f32>::try_from(&src).unwrap();
@@ -116,7 +116,7 @@ fn test_try_into_array4_2x3x4x5() {
 }
 
 #[test]
-fn test_try_into_array4_fail() {
+fn test_try_into_ndarray4_fail() {
     let hw = RefCell::new(CpuHardware::new());
     for n in [0, 1, 2, 3, 5, 6, 7, 8] {
         let src = Array::fill_f32(&hw, Shape::from_slice(&vec![1; n]), 42.);
@@ -125,7 +125,7 @@ fn test_try_into_array4_fail() {
 }
 
 #[test]
-fn test_try_into_array5_0x0x0x0x0() {
+fn test_try_into_ndarray5_0x0x0x0x0() {
     let hw = RefCell::new(CpuHardware::new());
     let src = Array::fill_f32(&hw, Shape::new([0, 0, 0, 0, 0]), 42.);
     let dest = ndarray::Array5::<f32>::try_from(&src).unwrap();
@@ -136,7 +136,7 @@ fn test_try_into_array5_0x0x0x0x0() {
 }
 
 #[test]
-fn test_try_into_array5_2x3x4x5x6() {
+fn test_try_into_ndarray5_2x3x4x5x6() {
     let hw = RefCell::new(CpuHardware::new());
     let src = Array::fill_f32(&hw, Shape::new([2, 3, 4, 5, 6]), 42.);
     let dest = ndarray::Array5::<f32>::try_from(&src).unwrap();
@@ -148,7 +148,7 @@ fn test_try_into_array5_2x3x4x5x6() {
 }
 
 #[test]
-fn test_try_into_array5_fail() {
+fn test_try_into_ndarray5_fail() {
     let hw = RefCell::new(CpuHardware::new());
     for n in [0, 1, 2, 3, 4, 6, 7, 8] {
         let src = Array::fill_f32(&hw, Shape::from_slice(&vec![1; n]), 42.);
@@ -157,7 +157,7 @@ fn test_try_into_array5_fail() {
 }
 
 #[test]
-fn test_try_into_array6_0x0x0x0x0x0() {
+fn test_try_into_ndarray6_0x0x0x0x0x0() {
     let hw = RefCell::new(CpuHardware::new());
     let src = Array::fill_f32(&hw, Shape::new([0, 0, 0, 0, 0, 0]), 42.);
     let dest = ndarray::Array6::<f32>::try_from(&src).unwrap();
@@ -168,7 +168,7 @@ fn test_try_into_array6_0x0x0x0x0x0() {
 }
 
 #[test]
-fn test_try_into_array6_2x3x4x5x6x7() {
+fn test_try_into_ndarray6_2x3x4x5x6x7() {
     let hw = RefCell::new(CpuHardware::new());
     let src = Array::fill_f32(&hw, Shape::new([2, 3, 4, 5, 6, 7]), 42.);
     let dest = ndarray::Array6::<f32>::try_from(&src).unwrap();
@@ -183,7 +183,7 @@ fn test_try_into_array6_2x3x4x5x6x7() {
 }
 
 #[test]
-fn test_try_into_array6_fail() {
+fn test_try_into_ndarray6_fail() {
     let hw = RefCell::new(CpuHardware::new());
     for n in [0, 1, 2, 3, 4, 5, 7, 8] {
         let src = Array::fill_f32(&hw, Shape::from_slice(&vec![1; n]), 42.);

--- a/src/array/tests.rs
+++ b/src/array/tests.rs
@@ -68,26 +68,15 @@ fn test_shape() {
 }
 
 #[test]
-fn test_set_scalar_f32_scalar() {
+fn test_set_scalar_f32() {
     let hw = RefCell::new(CpuHardware::new());
-    let mut array = unsafe { Array::raw(&hw, Shape::new([])) };
-    array.set_scalar_f32(123.).unwrap();
+    let array = unsafe {
+        let mut array = Array::raw(&hw, Shape::new([]));
+        array.set_scalar_f32(123.);
+        array
+    };
     assert_eq!(array.get_scalar_f32(), Ok(123.));
     assert_eq!(array.get_values_f32(), vec![123.]);
-}
-
-#[test]
-fn test_set_scalar_f32_1() {
-    let hw = RefCell::new(CpuHardware::new());
-    let mut array = unsafe { Array::raw(&hw, Shape::new([1])) };
-    assert!(array.set_scalar_f32(123.).is_err());
-}
-
-#[test]
-fn test_set_scalar_f32_n() {
-    let hw = RefCell::new(CpuHardware::new());
-    let mut array = unsafe { Array::raw(&hw, Shape::new([42])) };
-    assert!(array.set_scalar_f32(123.).is_err());
 }
 
 #[test]

--- a/src/array/tests.rs
+++ b/src/array/tests.rs
@@ -144,7 +144,7 @@ fn test_set_values_f32_n() {
 #[test]
 fn test_scalar_f32() {
     let hw = RefCell::new(CpuHardware::new());
-    let array = Array::scalar_f32(&hw, 123.);
+    let array = 123f32.into_array(&hw);
     assert_eq!(array.shape, Shape::new([]));
     assert_eq!(array.get_scalar_f32(), Ok(123.));
     assert_eq!(array.get_values_f32(), vec![123.]);
@@ -263,7 +263,7 @@ fn test_fill_colocated_f32_n() {
 #[test]
 fn test_elementwise_unary_f32_scalar() {
     let hw = RefCell::new(CpuHardware::new());
-    let x = Array::scalar_f32(&hw, 123.);
+    let x = 123f32.into_array(&hw);
 
     let y = x.elementwise_neg_f32();
     assert_eq!(y.shape, Shape::new([]));
@@ -296,8 +296,8 @@ fn test_elementwise_unary_f32_n() {
 #[test]
 fn test_elementwise_binary_f32_scalar_scalar() {
     let hw = RefCell::new(CpuHardware::new());
-    let a = Array::scalar_f32(&hw, 111.);
-    let b = Array::scalar_f32(&hw, 222.);
+    let a = 111f32.into_array(&hw);
+    let b = 222f32.into_array(&hw);
 
     let y = a.elementwise_add_f32(&b).unwrap();
     assert_eq!(y.shape, Shape::new([]));
@@ -323,7 +323,7 @@ fn test_elementwise_binary_f32_scalar_scalar() {
 #[test]
 fn test_elementwise_binary_f32_scalar_self() {
     let hw = RefCell::new(CpuHardware::new());
-    let a = Array::scalar_f32(&hw, 111.);
+    let a = 111f32.into_array(&hw);
 
     let y = a.elementwise_add_f32(&a).unwrap();
     assert_eq!(y.shape, Shape::new([]));
@@ -456,7 +456,7 @@ fn test_elementwise_binary_f32_n_self() {
 #[test]
 fn test_elementwise_binary_f32_scalar_0() {
     let hw = RefCell::new(CpuHardware::new());
-    let a = Array::scalar_f32(&hw, 111.);
+    let a = 111f32.into_array(&hw);
     let b = Array::constant_f32(&hw, Shape::new([0]), &[]).unwrap();
 
     assert!(a.elementwise_add_f32(&b).is_err());
@@ -473,7 +473,7 @@ fn test_elementwise_binary_f32_scalar_0() {
 #[test]
 fn test_elementwise_binary_f32_scalar_1() {
     let hw = RefCell::new(CpuHardware::new());
-    let a = Array::scalar_f32(&hw, 111.);
+    let a = 111f32.into_array(&hw);
     let b = Array::constant_f32(&hw, Shape::new([1]), &[444.]).unwrap();
 
     assert!(a.elementwise_add_f32(&b).is_err());
@@ -490,7 +490,7 @@ fn test_elementwise_binary_f32_scalar_1() {
 #[test]
 fn test_elementwise_binary_f32_scalar_n() {
     let hw = RefCell::new(CpuHardware::new());
-    let a = Array::scalar_f32(&hw, 111.);
+    let a = 111f32.into_array(&hw);
     let b = Array::constant_f32(&hw, Shape::new([3]), &[444., 555., 666.]).unwrap();
 
     assert!(a.elementwise_add_f32(&b).is_err());
@@ -559,8 +559,8 @@ fn test_elementwise_binary_f32_1_n() {
 fn test_elementwise_binary_f32_colocation() {
     let hw1 = RefCell::new(CpuHardware::new());
     let hw2 = RefCell::new(CpuHardware::new());
-    let a = Array::scalar_f32(&hw1, 123.);
-    let b = Array::scalar_f32(&hw2, 123.);
+    let a = 123f32.into_array(&hw1);
+    let b = 123f32.into_array(&hw2);
 
     assert!(a.elementwise_add_f32(&b).is_err());
     assert!(a.elementwise_sub_f32(&b).is_err());
@@ -576,7 +576,7 @@ fn test_elementwise_binary_f32_colocation() {
 #[test]
 fn test_clone_scalar() {
     let hw = RefCell::new(CpuHardware::new());
-    let x = Array::scalar_f32(&hw, 123.);
+    let x = 123f32.into_array(&hw);
     let y = x.clone();
     assert_eq!(y.shape, Shape::new([]));
     assert!(ptr::eq(y.hardware(), &hw));

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -186,11 +186,9 @@ impl<'hw: 'op, 'op> Graph<'hw, 'op> {
     /// # Returns
     ///
     /// * Calculated/cached value associated to `target`.
-    pub(crate) fn calculate(&mut self, target: usize) -> Result<Array<'hw>> {
+    pub(crate) fn calculate(&mut self, target: usize) -> Array<'hw> {
         // Avoiding an edge case: inner step_ids should be correct, but `target` is not constrained.
-        if target >= self.steps.len() {
-            return Err(Error::InvalidNode(format!("Invalid step ID: {}", target)));
-        }
+        assert!(target < self.steps.len(), "Invalid step ID: {}", target);
 
         // Actions for the push-down automaton representing the following procedure:
         /*
@@ -251,11 +249,11 @@ impl<'hw: 'op, 'op> Graph<'hw, 'op> {
         }
 
         // The `target` step must own a calculated value.
-        Ok(unsafe { self.steps.get_unchecked(target) }
+        unsafe { self.steps.get_unchecked(target) }
             .output
             .array()
             .unwrap()
-            .clone())
+            .clone()
     }
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -250,6 +250,7 @@ impl<'hw: 'op, 'op> Graph<'hw, 'op> {
             }
         }
 
+        // The `target` step must own a calculated value.
         Ok(unsafe { self.steps.get_unchecked(target) }
             .output
             .array()

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -250,13 +250,11 @@ impl<'hw: 'op, 'op> Graph<'hw, 'op> {
             }
         }
 
-        if let ArrayPlaceholder::Assigned(ref array) =
-            unsafe { self.steps.get_unchecked(target) }.output
-        {
-            return Ok(array.clone());
-        }
-
-        panic!("Target step could not be calculated for some reason.");
+        Ok(unsafe { self.steps.get_unchecked(target) }
+            .output
+            .array()
+            .unwrap()
+            .clone())
     }
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -186,7 +186,7 @@ impl<'hw: 'op, 'op> Graph<'hw, 'op> {
     /// # Returns
     ///
     /// * Calculated/cached value associated to `target`.
-    pub(crate) fn calculate(&mut self, target: usize) -> Array<'hw> {
+    pub(crate) fn calculate(&mut self, target: usize) -> &Array<'hw> {
         // Avoiding an edge case: inner step_ids should be correct, but `target` is not constrained.
         assert!(target < self.steps.len(), "Invalid step ID: {}", target);
 
@@ -253,7 +253,6 @@ impl<'hw: 'op, 'op> Graph<'hw, 'op> {
             .output
             .array()
             .unwrap()
-            .clone()
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -75,7 +75,7 @@ impl<'hw: 'op, 'op: 'g, 'g> Node<'hw, 'op, 'g> {
     }
 
     pub fn calculate(&self) -> Array<'hw> {
-        self.graph.borrow_mut().calculate(self.step_id)
+        self.graph.borrow_mut().calculate(self.step_id).clone()
     }
 
     /// Registers `Fill` operation to the graph.

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,4 @@
-use crate::array::Array;
+use crate::array::{Array, IntoArray};
 use crate::error::Error;
 use crate::graph::Graph;
 use crate::hardware::Hardware;
@@ -34,9 +34,9 @@ impl<'hw: 'op, 'op: 'g, 'g> Node<'hw, 'op, 'g> {
             graph
                 .borrow_mut()
                 .add_step(
-                    Box::new(operator::constant::Constant::new(Array::scalar_f32(
-                        hardware, value,
-                    ))),
+                    Box::new(operator::constant::Constant::new(
+                        value.into_array(hardware),
+                    )),
                     vec![],
                 )
                 .unwrap(),

--- a/src/node.rs
+++ b/src/node.rs
@@ -74,7 +74,7 @@ impl<'hw: 'op, 'op: 'g, 'g> Node<'hw, 'op, 'g> {
             .hardware()
     }
 
-    pub fn calculate(&self) -> crate::result::Result<Array<'hw>> {
+    pub fn calculate(&self) -> Array<'hw> {
         self.graph.borrow_mut().calculate(self.step_id)
     }
 
@@ -129,7 +129,7 @@ impl<'hw: 'op, 'op: 'g, 'g> Eq for Node<'hw, 'op, 'g> {}
 impl<'hw: 'op, 'op: 'g, 'g> TryFrom<Node<'hw, 'op, 'g>> for f32 {
     type Error = Error;
     fn try_from(node: Node<'hw, 'op, 'g>) -> Result<Self> {
-        node.calculate()?.get_scalar_f32()
+        node.calculate().get_scalar_f32()
     }
 }
 

--- a/src/node/convert_ndarray.rs
+++ b/src/node/convert_ndarray.rs
@@ -8,7 +8,7 @@ macro_rules! define_try_from_node {
         impl<'hw: 'op, 'op: 'g, 'g> TryFrom<Node<'hw, 'op, 'g>> for $dest {
             type Error = Error;
             fn try_from(src: Node<'hw, 'op, 'g>) -> Result<Self> {
-                Self::try_from(&src.calculate()?)
+                Self::try_from(&src.calculate())
             }
         }
     };

--- a/src/node/tests.rs
+++ b/src/node/tests.rs
@@ -27,7 +27,7 @@ fn test_steps() {
         assert_eq!(g.get_step(2).unwrap().operator.name(), "Add");
     }
 
-    let retval = ret.calculate().unwrap();
+    let retval = ret.calculate();
     assert_eq!(*retval.shape(), Shape::new([]));
     assert_eq!(retval.get_scalar_f32(), Ok(3.));
 }
@@ -45,7 +45,7 @@ fn test_neg() {
     assert!(ptr::eq(src.hardware(), &hw));
     assert!(ptr::eq(dest.hardware(), &hw));
 
-    assert_eq!(dest.calculate().unwrap().get_scalar_f32(), Ok(-42.));
+    assert_eq!(dest.calculate().get_scalar_f32(), Ok(-42.));
 }
 
 #[test]
@@ -64,7 +64,7 @@ fn test_add() {
     assert!(ptr::eq(rhs.hardware(), &hw));
     assert!(ptr::eq(ret.hardware(), &hw));
 
-    assert_eq!(ret.calculate().unwrap().get_scalar_f32(), Ok(3.));
+    assert_eq!(ret.calculate().get_scalar_f32(), Ok(3.));
 }
 
 #[test]
@@ -83,7 +83,7 @@ fn test_sub() {
     assert!(ptr::eq(rhs.hardware(), &hw));
     assert!(ptr::eq(ret.hardware(), &hw));
 
-    assert_eq!(ret.calculate().unwrap().get_scalar_f32(), Ok(-1.));
+    assert_eq!(ret.calculate().get_scalar_f32(), Ok(-1.));
 }
 
 #[test]
@@ -141,7 +141,7 @@ fn test_fill_0() {
     let ret = Node::fill(&g, &hw, Shape::new([0]), 123.);
     assert_eq!(ret.shape(), Shape::new([0]));
     assert!(ptr::eq(ret.hardware(), &hw));
-    assert_eq!(ret.calculate().unwrap().get_values_f32(), vec![]);
+    assert_eq!(ret.calculate().get_values_f32(), vec![]);
 }
 
 #[test]
@@ -151,10 +151,7 @@ fn test_fill_n() {
     let ret = Node::fill(&g, &hw, Shape::new([3]), 123.);
     assert_eq!(ret.shape(), Shape::new([3]));
     assert!(ptr::eq(ret.hardware(), &hw));
-    assert_eq!(
-        ret.calculate().unwrap().get_values_f32(),
-        vec![123., 123., 123.]
-    );
+    assert_eq!(ret.calculate().get_values_f32(), vec![123., 123., 123.]);
 }
 
 #[test]

--- a/src/operator/add.rs
+++ b/src/operator/add.rs
@@ -46,6 +46,7 @@ impl Gradient for AddGrad {
 
 #[cfg(test)]
 mod tests {
+    use crate::array::IntoArray;
     use crate::hardware::cpu::CpuHardware;
     use crate::operator::add::*;
 
@@ -92,9 +93,9 @@ mod tests {
     fn test_perform() {
         let hw = RefCell::new(CpuHardware::new());
         let op = Add::new();
-        let lhs = Array::scalar_f32(&hw, 1.);
-        let rhs = Array::scalar_f32(&hw, 2.);
-        let expected = Array::scalar_f32(&hw, 3.);
+        let lhs = 1f32.into_array(&hw);
+        let rhs = 2f32.into_array(&hw);
+        let expected = 3f32.into_array(&hw);
         let observed = op.perform(&[&lhs, &rhs]).unwrap();
         assert_eq!(observed.shape(), expected.shape());
         assert_eq!(observed.get_scalar_f32(), expected.get_scalar_f32());

--- a/src/operator/constant.rs
+++ b/src/operator/constant.rs
@@ -37,13 +37,14 @@ impl<'hw> Operator<'hw> for Constant<'hw> {
 
 #[cfg(test)]
 mod tests {
+    use crate::array::IntoArray;
     use crate::hardware::cpu::CpuHardware;
     use crate::operator::constant::*;
 
     #[test]
     fn test_properties() {
         let hw = RefCell::new(CpuHardware::new());
-        let op = Constant::new(Array::scalar_f32(&hw, 123.));
+        let op = Constant::new(123f32.into_array(&hw));
         assert_eq!(op.name(), "Constant");
         assert_eq!(op.input_size(), 0);
     }
@@ -51,7 +52,7 @@ mod tests {
     #[test]
     fn test_perform_shape_scalar() {
         let hw = RefCell::new(CpuHardware::new());
-        let op = Constant::new(Array::scalar_f32(&hw, 123.));
+        let op = Constant::new(123f32.into_array(&hw));
         assert_eq!(op.perform_shape(&[]), Ok(Shape::new([])));
     }
 
@@ -72,15 +73,15 @@ mod tests {
     #[test]
     fn test_perform_hardware() {
         let hw = RefCell::new(CpuHardware::new());
-        let op = Constant::new(Array::scalar_f32(&hw, 123.));
+        let op = Constant::new(123f32.into_array(&hw));
         assert!(ptr::eq(op.perform_hardware(&[]).unwrap(), &hw));
     }
 
     #[test]
     fn test_perform() {
         let hw = RefCell::new(CpuHardware::new());
-        let op = Constant::new(Array::scalar_f32(&hw, 123.));
-        let expected = Array::scalar_f32(&hw, 123.);
+        let op = Constant::new(123f32.into_array(&hw));
+        let expected = 123f32.into_array(&hw);
         let observed = op.perform(&[]).unwrap();
         assert_eq!(observed.shape(), expected.shape());
         assert_eq!(observed.get_scalar_f32(), expected.get_scalar_f32());

--- a/src/operator/div.rs
+++ b/src/operator/div.rs
@@ -47,6 +47,7 @@ impl Gradient for DivGrad {
 
 #[cfg(test)]
 mod tests {
+    use crate::array::IntoArray;
     use crate::hardware::cpu::CpuHardware;
     use crate::operator::div::*;
 
@@ -93,9 +94,9 @@ mod tests {
     fn test_perform() {
         let hw = RefCell::new(CpuHardware::new());
         let op = Div::new();
-        let lhs = Array::scalar_f32(&hw, 1.);
-        let rhs = Array::scalar_f32(&hw, 2.);
-        let expected = Array::scalar_f32(&hw, 0.5);
+        let lhs = 1f32.into_array(&hw);
+        let rhs = 2f32.into_array(&hw);
+        let expected = (0.5f32).into_array(&hw);
         let observed = op.perform(&[&lhs, &rhs]).unwrap();
         assert_eq!(observed.shape(), expected.shape());
         assert_eq!(observed.get_scalar_f32(), expected.get_scalar_f32());

--- a/src/operator/mul.rs
+++ b/src/operator/mul.rs
@@ -46,6 +46,7 @@ impl Gradient for MulGrad {
 
 #[cfg(test)]
 mod tests {
+    use crate::array::IntoArray;
     use crate::hardware::cpu::CpuHardware;
     use crate::operator::mul::*;
 
@@ -92,9 +93,9 @@ mod tests {
     fn test_perform() {
         let hw = RefCell::new(CpuHardware::new());
         let op = Mul::new();
-        let lhs = Array::scalar_f32(&hw, 1.);
-        let rhs = Array::scalar_f32(&hw, 2.);
-        let expected = Array::scalar_f32(&hw, 2.);
+        let lhs = 1f32.into_array(&hw);
+        let rhs = 2f32.into_array(&hw);
+        let expected = 2f32.into_array(&hw);
         let observed = op.perform(&[&lhs, &rhs]).unwrap();
         assert_eq!(observed.shape(), expected.shape());
         assert_eq!(observed.get_scalar_f32(), expected.get_scalar_f32());

--- a/src/operator/neg.rs
+++ b/src/operator/neg.rs
@@ -46,6 +46,7 @@ impl Gradient for NegGrad {
 
 #[cfg(test)]
 mod tests {
+    use crate::array::IntoArray;
     use crate::hardware::cpu::CpuHardware;
     use crate::operator::neg::*;
 
@@ -78,8 +79,8 @@ mod tests {
     fn test_perform() {
         let hw = RefCell::new(CpuHardware::new());
         let op = Neg::new();
-        let input = Array::scalar_f32(&hw, 42.);
-        let expected = Array::scalar_f32(&hw, -42.);
+        let input = 42f32.into_array(&hw);
+        let expected = (-42f32).into_array(&hw);
         let observed = op.perform(&[&input]).unwrap();
         assert_eq!(observed.shape(), expected.shape());
         assert_eq!(observed.get_scalar_f32(), expected.get_scalar_f32());

--- a/src/operator/sub.rs
+++ b/src/operator/sub.rs
@@ -46,6 +46,7 @@ impl Gradient for SubGrad {
 
 #[cfg(test)]
 mod tests {
+    use crate::array::IntoArray;
     use crate::hardware::cpu::CpuHardware;
     use crate::operator::sub::*;
 
@@ -92,9 +93,9 @@ mod tests {
     fn test_perform() {
         let hw = RefCell::new(CpuHardware::new());
         let op = Sub::new();
-        let lhs = Array::scalar_f32(&hw, 1.);
-        let rhs = Array::scalar_f32(&hw, 2.);
-        let expected = Array::scalar_f32(&hw, -1.);
+        let lhs = 1f32.into_array(&hw);
+        let rhs = 2f32.into_array(&hw);
+        let expected = (-1f32).into_array(&hw);
         let observed = op.perform(&[&lhs, &rhs]).unwrap();
         assert_eq!(observed.shape(), expected.shape());
         assert_eq!(observed.get_scalar_f32(), expected.get_scalar_f32());


### PR DESCRIPTION
This change adds `impl IntoArray for ndarray::ArrayN` where N is 0 t 6.
Since our `Array` supports only data with the row-major order, this implementation converts the source array to row-major first (if necessary), then copies the underlying data into `Array`.

Blocking change: #27